### PR TITLE
Fix Docker build issue

### DIFF
--- a/dev/bin/docker-build.sh
+++ b/dev/bin/docker-build.sh
@@ -22,7 +22,7 @@ if [[ "$BRANCH" == "master" ]]; then
 elif [[ "$BRANCH" == "develop" ]]; then
   export TAG="develop";
 else
-  export TAG=$BRANCH;
+  export TAG=$COMMIT;
 fi
 
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
- Docker tags are more restrictive than git branch names so use the
  commit id as the Docker tag rather than the branch name