### PR TITLE
Update projects to use ASP.NET Core 2.1.1

### DIFF
--- a/src/Ops.Controllers/Ops.Controllers.csproj
+++ b/src/Ops.Controllers/Ops.Controllers.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommonMark.NET" Version="0.15.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="CommonMark.NET" Version="0.15.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.Data/Ops.Data.csproj
+++ b/src/Ops.Data/Ops.Data.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
+++ b/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -34,16 +34,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="2.7.385" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.2" />
-    <PackageReference Include="Serilog.Sinks.Rollingfile" Version="3.3.0" />
+    <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
+    <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.*" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.*" />
+    <PackageReference Include="Serilog.Sinks.Rollingfile" Version="3.3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.Controllers/Promenade.Controllers.csproj
+++ b/src/Promenade.Controllers/Promenade.Controllers.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -32,16 +32,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BuildBundlerMinifier" Version="2.7.385" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Serilog.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.1" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.2" />
-    <PackageReference Include="Serilog.Sinks.Rollingfile" Version="3.3.0" />
+    <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
+    <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.*" />
+    <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="5.1.*" />
+    <PackageReference Include="Serilog.Sinks.Rollingfile" Version="3.3.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0-rc1-final" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update projects to wildcard package references which should bump to ASP.NET Core 2.1.1