### PR TITLE
Updates to support ASP.NET Core 2.1 properly

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -4,10 +4,10 @@
 
 Ocuda targets the ASP.NET Core 2.1 framework. For that to work currently you must:
 
-- Install the [.NET Core 2.1.0-rc1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-rc1)
+- Install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300)
 - Ensure you're using [Visual Studio Update 7](https://visualstudio.com/vs)
 
-For more details see the ASP.NET Blog post about [ASP.NET Core 2.1.0-rc1](https://blogs.msdn.microsoft.com/webdev/2018/05/07/asp-net-core-2-1-0-rc1-now-available/).
+For more details see the ASP.NET Blog post about [ASP.NET Core 2.1.0](https://blogs.msdn.microsoft.com/webdev/2018/05/30/asp-net-core-2-1-0-now-available/).
 
 ## Project layout
 

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.*" PrivateAssets="All" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Ops.Web/Startup.cs
+++ b/src/Ops.Web/Startup.cs
@@ -94,7 +94,6 @@ namespace Ocuda.Ops.Web
             // configure error page handling and development IDE linking
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
             else

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.*" PrivateAssets="All" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -50,7 +50,6 @@ namespace Ocuda.Promenade.Web
             // configure error page handling and development IDE linking
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
             else


### PR DESCRIPTION
- Remove BrowserLink
- Add references to Microsoft.VisualStudio.Web.CodeGeneration.Design
  per Microsoft guidance ('Migrate from ASP.NET Core 2.0 to 2.1')
- Update dev readme to link to proper SDK download