### PR TITLE
 Update projects to use .NET Core 2.1.1

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -4,10 +4,10 @@
 
 Ocuda targets the ASP.NET Core 2.1 framework. For that to work currently you must:
 
-- Install the [.NET Core 2.1.0-rc1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300-rc1)
+- Install the [.NET Core 2.1 SDK](https://www.microsoft.com/net/download/dotnet-core/sdk-2.1.300)
 - Ensure you're using [Visual Studio Update 7](https://visualstudio.com/vs)
 
-For more details see the ASP.NET Blog post about [ASP.NET Core 2.1.0-rc1](https://blogs.msdn.microsoft.com/webdev/2018/05/07/asp-net-core-2-1-0-rc1-now-available/).
+For more details see the ASP.NET Blog post about [ASP.NET Core 2.1.0](https://blogs.msdn.microsoft.com/webdev/2018/05/30/asp-net-core-2-1-0-now-available/).
 
 ## Project layout
 

--- a/src/Ops.Controllers/Ops.Controllers.csproj
+++ b/src/Ops.Controllers/Ops.Controllers.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommonMark.NET" Version="0.15.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
+++ b/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -35,10 +35,9 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.*" PrivateAssets="All" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Ops.Web/Startup.cs
+++ b/src/Ops.Web/Startup.cs
@@ -94,7 +94,6 @@ namespace Ocuda.Ops.Web
             // configure error page handling and development IDE linking
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
             else

--- a/src/Promenade.Controllers/Promenade.Controllers.csproj
+++ b/src/Promenade.Controllers/Promenade.Controllers.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -33,9 +33,9 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="BuildBundlerMinifier" Version="2.8.*" />
     <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.*" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.1.*" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.*" PrivateAssets="All" />
     <PackageReference Include="Serilog.AspNetCore" Version="2.1.*" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="1.1.*" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="2.6.*" />

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -50,7 +50,6 @@ namespace Ocuda.Promenade.Web
             // configure error page handling and development IDE linking
             if (env.IsDevelopment())
             {
-                app.UseBrowserLink();
                 app.UseDeveloperExceptionPage();
             }
             else

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update projects to wildcard package references which should bump to
  ASP.NET Core 2.1.1
- Remove BrowserLink
- Add references to Microsoft.VisualStudio.Web.CodeGeneration.Design
  per Microsoft guidance ('Migrate from ASP.NET Core 2.0 to 2.1')
- Update dev readme to link to proper SDK download