### PR TITLE
Add static file hosting to promenade

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -69,6 +69,9 @@ _Eventually this should be moved to the user documentation._
 - `SerilogSoftwareLogs` - SQL Server connection string for writing application logs out, if unset logs are not written to SQL Server
 
 ##### Settings
+- `Ocuda.FileShared` - defaults to "shared" - a file location shared among any instances of the site which are running for handling site assets
+- `Ocuda.UrlSharedContent` - defaults to "content" - a mapping to the public shared file directory (which is "public" under the configured `Ocuda.FileShared`)
+
 - `OpsAuthBlankRequestRedirect` - *used only by Ops.Web.WindowsAuth* - if the authentication site is loaded with no id or directive then redirect to this URL
 - `Ops.AuthRedirect` - URL to the deployed Ops.Web.WindowsAuth site - if not specified authentication will not function
 - `Ops.AuthTimeoutMinutes` - defaults to 2 minutes - timeout for authentication bits (cookie and distributed cache elements)
@@ -77,7 +80,6 @@ _Eventually this should be moved to the user documentation._
 - `Ops.DistributedCacheInstanceDiscriminator` - if set, appends the string to distributed cache keys in order to isolate them from other instances (e.g. if multiple developers are using the same distributed cache)
 - `Ops.DistributedCache.RedisConfiguration` - *also used by Ops.Web.WindowsAuth* - if *Ops.DistributedCache* is set to 'Redis' this must be set with Redis configuration information, see the [RedisCacheOptions.Configuration property](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.caching.redis.rediscacheoptions.configuration)
 - `Ops.DomainName` - an Active Directory domain name to remove from the beginning of authenticated users (do not include the slash)
-- `Ops.FileShared` - defaults to "shared" - a file location shared among any instances of the site which are running for handling site assets
 - `Ops.HttpErrorFileTag` - if *Ops.RollingLogLocation* is set, this will write out http error logs in the same location but with the value of this setting in the filename
 - `Ops.Instance` - configure an instance name for more specific logging
 - `Ops.LDAPDN` - Distinguished name of an LDAP user for performing lookups, similar to "CN=Users Real Name,OU=Organizational Unit,DC=domain,DC=tld"
@@ -89,7 +91,6 @@ _Eventually this should be moved to the user documentation._
 - `Ops.SessionTimeoutMinutes` - defaults to 2 hours - amount of time in minutes for sessions to last
 - `Ops.SiteManagerGroup` - if specified, this authentication group (currently ADGroup) will be granted site manager access
 - `Ops.SiteSettingCacheMinutes` - defaults to 60 minutes - how long to cache site setting values
-- `Ops.UrlSharedContent` - defaults to "content" - a mapping to the public shared file directory (which is "public" under the configured `Ops.FileShared`)
 
 ### Promenade
 
@@ -97,4 +98,7 @@ _Eventually this should be moved to the user documentation._
 - `Promenade.DatabaseProvider` - which database provider to use, must currently be set to: `SqlServer`
 
 #### Optional
+- `Ocuda.FileShared` - defaults to "shared" - a file location shared among any instances of the site which are running for handling site assets
+- `Ocuda.UrlSharedContent` - defaults to "content" - a mapping to the public shared file directory (which is "public" under the configured `Ocuda.FileShared`)
+
 - `Promenade.Culture` - defaults to "en-US", the culture to use for displaying things like dates and times - for valid options see the language tags listed in the [Microsoft National Language Support (NLS) API Reference](http://go.microsoft.com/fwlink/?LinkId=200048)

--- a/src/Ops.Service/FileService.cs
+++ b/src/Ops.Service/FileService.cs
@@ -12,6 +12,7 @@ using Ocuda.Ops.Service.Interfaces.Ops.Services;
 using Ocuda.Ops.Service.Models;
 using Ocuda.Utility.Exceptions;
 using Ocuda.Utility.Helpers;
+using Ocuda.Utility.Services.Interfaces;
 
 namespace Ocuda.Ops.Service
 {

--- a/src/Ops.Web/appsettings.Development.json
+++ b/src/Ops.Web/appsettings.Development.json
@@ -7,7 +7,7 @@
   "Ocuda.Instance": "ops.dev",
   "Ocuda.LoggingRollingFile": "logs",
   "Ocuda.LoggingRollingHttpFile": "http",
-  "Ops.UrlSharedContent": "/shared/public",
+  "Ocuda.UrlSharedContent": "/shared/public",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -19,6 +19,7 @@ using Ocuda.i18n.RouteConstraint;
 using Ocuda.Promenade.Data;
 using Ocuda.Promenade.Service;
 using Ocuda.Utility.Abstract;
+using Ocuda.Utility.Exceptions;
 using Ocuda.Utility.Keys;
 using Ocuda.Utility.Providers;
 using Serilog.Context;
@@ -87,7 +88,7 @@ namespace Ocuda.Promenade.Web
             }
 
             string promCs = _config.GetConnectionString("Promenade")
-                ?? throw new Exception("ConnectionString:Promenade not configured.");
+                ?? throw new OcudaException("ConnectionString:Promenade not configured.");
             switch (_config["Promenade.DatabaseProvider"])
             {
                 case "SqlServer":
@@ -99,7 +100,7 @@ namespace Ocuda.Promenade.Web
                             .Ignore(ignoreEvents.ToArray())));
                     break;
                 default:
-                    throw new System.Exception("No Ops.DatabaseProvider configured.");
+                    throw new OcudaException("No Ops.DatabaseProvider configured.");
             }
 
             services.Configure<RouteOptions>(_ =>
@@ -173,6 +174,10 @@ namespace Ocuda.Promenade.Web
                 Data.Promenade.UrlRedirectRepository>();
 
             // services
+            services.AddScoped<Utility.Services.Interfaces.IPathResolverService,
+                Utility.Services.PathResolverService>();
+
+            // promenade servicews
             services.AddScoped<CategoryService>();
             services.AddScoped<EmediaService>();
             services.AddScoped<LanguageService>();
@@ -185,7 +190,8 @@ namespace Ocuda.Promenade.Web
             services.AddScoped<SocialCardService>();
         }
 
-        public void Configure(IApplicationBuilder app)
+        public void Configure(IApplicationBuilder app,
+            Utility.Services.Interfaces.IPathResolverService pathResolver)
         {
             // configure error page handling and development IDE linking
             if (_isDevelopment)
@@ -225,8 +231,22 @@ namespace Ocuda.Promenade.Web
 
             app.UseStaticFiles();
 
+            // configure shared content directory
+            var contentFilePath = pathResolver.GetPublicContentFilePath();
+            var contentUrl = pathResolver.GetPublicContentUrl();
+            if (!contentUrl.StartsWith("/", StringComparison.OrdinalIgnoreCase))
+            {
+                contentUrl = $"/{contentUrl}";
+            }
+
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                FileProvider
+                    = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(contentFilePath),
+                RequestPath = new PathString(contentUrl)
+            });
+
             app.UseMvc();
         }
     }
 }
-

--- a/src/Promenade.Web/appsettings.Development.json
+++ b/src/Promenade.Web/appsettings.Development.json
@@ -6,6 +6,7 @@
   "Ocuda.Instance": "promenade.dev",
   "Ocuda.LoggingRollingFile": "logs",
   "Ocuda.LoggingRollingHttpFile": "http",
+  "Ocuda.UrlSharedContent": "/assets",
   "Serilog": {
     "MinimumLevel": {
       "Default": "Debug",

--- a/src/Utility/Keys/Configuration.cs
+++ b/src/Utility/Keys/Configuration.cs
@@ -8,6 +8,9 @@
         public static readonly string OcudaLoggingRollingFile = "Ocuda.LoggingRollingFile";
         public static readonly string OcudaLoggingRollingHttpFile = "Ocuda.LoggingRollingHttpFile";
 
+        public static readonly string OcudaUrlSharedContent = "Ocuda.UrlSharedContent";
+        public static readonly string OcudaFileShared = "Ocuda.FileShared";
+
         public static readonly string ThrowQueryWarningsInDev = "ThrowQueryWarningsInDev";
 
         public static readonly string OpsAuthBlankRequestRedirect = "Ops.AuthBlankRequestRedirect";
@@ -24,7 +27,6 @@
             = "Ops.DistributedCache.RedisConfiguration";
 
         public static readonly string OpsDomainName = "Ops.DomainName";
-        public static readonly string OpsFileShared = "Ops.FileShared";
         public static readonly string OpsHttpErrorFileTag = "Ops.HttpErrorFileTag";
         public static readonly string OpsLdapDn = "Ops.LDAPDN";
         public static readonly string OpsLdapPassword = "Ops.LDAPPassword";
@@ -35,7 +37,6 @@
         public static readonly string OpsSiteManagerGroup = "Ops.SiteManagerGroup";
         public static readonly string OpsSiteSettingCacheMinutes = "Ops.SiteSettingCacheMinutes";
         public static readonly string OpsSessionTimeoutMinutes = "Ops.SessionTimeoutMinutes";
-        public static readonly string OpsUrlSharedContent = "Ops.UrlSharedContent";
 
         public static readonly string PromAPIGoogleMaps = "Promenade.API.GoogleMaps";
         public static readonly string OpsAPIGoogleMaps = "Ops.API.GoogleMaps";

--- a/src/Utility/Services/Interfaces/IPathResolverService.cs
+++ b/src/Utility/Services/Interfaces/IPathResolverService.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Ocuda.Ops.Service.Interfaces.Ops.Services
+﻿namespace Ocuda.Utility.Services.Interfaces
 {
     public interface IPathResolverService
     {

--- a/src/Utility/Services/PathResolverService.cs
+++ b/src/Utility/Services/PathResolverService.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Text;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
-using Ocuda.Ops.Service.Interfaces.Ops.Services;
 
-namespace Ocuda.Ops.Service
+namespace Ocuda.Utility.Services
 {
-    public class PathResolverService : IPathResolverService
+    public class PathResolverService : Interfaces.IPathResolverService
     {
         private const string DefaultPublicDirectory = "public";
         private const string DefaultPrivateDirectory = "private";
@@ -24,18 +22,22 @@ namespace Ocuda.Ops.Service
 
         public string GetPublicContentUrl(params object[] pathElement)
         {
-            var path = new StringBuilder(_config[Utility.Keys.Configuration.OpsUrlSharedContent]);
+            var path = new StringBuilder(_config[Keys.Configuration.OcudaUrlSharedContent]);
             if (path.Length == 0)
             {
                 path.Append("content");
             }
-            foreach (var element in pathElement)
+            if (pathElement != null)
             {
-                if (!path.ToString().EndsWith("/") && !element.ToString().StartsWith("/"))
+                foreach (var element in pathElement)
                 {
-                    path.Append("/");
+                    if (!path.ToString().EndsWith("/", StringComparison.OrdinalIgnoreCase)
+                        && !element.ToString().StartsWith("/", StringComparison.OrdinalIgnoreCase))
+                    {
+                        path.Append("/");
+                    }
+                    path.Append(element);
                 }
-                path.Append(element);
             }
             return path.ToString();
         }
@@ -60,13 +62,12 @@ namespace Ocuda.Ops.Service
                 ? DefaultPrivateDirectory
                 : DefaultPublicDirectory;
 
-            string path
-                = Utility.Files.SharedPath.Get(_config[Utility.Keys.Configuration.OpsFileShared]);
+            string path = Files.SharedPath.Get(_config[Keys.Configuration.OcudaFileShared]);
 
             try
             {
-                path = Path.Combine(path, publicPrivateRoot);
-                Directory.CreateDirectory(path);
+                path = System.IO.Path.Combine(path, publicPrivateRoot);
+                System.IO.Directory.CreateDirectory(path);
             }
             catch (Exception ex)
             {
@@ -77,11 +78,11 @@ namespace Ocuda.Ops.Service
 
             foreach (var element in pathElement)
             {
-                path = Path.Combine(path, element.ToString());
+                path = System.IO.Path.Combine(path, element.ToString());
 
                 try
                 {
-                    Directory.CreateDirectory(path);
+                    System.IO.Directory.CreateDirectory(path);
                 }
                 catch (Exception ex)
                 {
@@ -93,7 +94,7 @@ namespace Ocuda.Ops.Service
 
             if (!string.IsNullOrEmpty(fileName))
             {
-                path = Path.Combine(path, fileName);
+                path = System.IO.Path.Combine(path, fileName);
             }
 
             return path;


### PR DESCRIPTION
- Refactor static file serving from Ops to work in both projects
- Change settings from `Ops.FileShared` and `Ops.UrlSharedContent` to
be prefixed with `Ocuda` instead of `Ops`.