### PR TITLE
Add distributed caching to Promenade

### DIFF
--- a/src/Ops.Web/Startup.cs
+++ b/src/Ops.Web/Startup.cs
@@ -37,6 +37,9 @@ namespace Ocuda.Ops.Web
             _isDevelopment = env.IsDevelopment();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability",
+            "CA1506:Avoid excessive class coupling",
+            Justification = "Dependency injection")]
         public void ConfigureServices(IServiceCollection services)
         {
             // set a default culture of en-US if none is specified
@@ -52,7 +55,7 @@ namespace Ocuda.Ops.Web
                 case "Redis":
                     string redisConfiguration
                         = _config[Configuration.OpsDistributedCacheRedisConfiguration]
-                        ?? throw new OcudaException($"{Configuration.OpsDistributedCache} has Redis selected but {Configuration.OpsDistributedCacheRedisConfiguration} is not set.");
+                        ?? throw new OcudaException("Configuration.OpsDistributedCache has Redis selected but Configuration.OpsDistributedCacheRedisConfiguration is not set.");
                     string instanceName = CacheInstance.OcudaOps;
                     if (!instanceName.EndsWith(".", StringComparison.OrdinalIgnoreCase))
                     {
@@ -94,7 +97,7 @@ namespace Ocuda.Ops.Web
                         DataProvider.SqlServer.Promenade.Context>(_ => _.UseSqlServer(promCs));
                     break;
                 default:
-                    throw new OcudaException($"No {Configuration.OpsDatabaseProvider} configured.");
+                    throw new OcudaException("No Configuration.OpsDatabaseProvider configured.");
             }
 
             // stoer the data protection key in the context

--- a/src/Promenade.Controllers/Abstract/BaseController.cs
+++ b/src/Promenade.Controllers/Abstract/BaseController.cs
@@ -36,7 +36,8 @@ namespace Ocuda.Promenade.Controllers.Abstract
             _siteSettingService = context.SiteSettingService;
         }
 
-        public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        public override async Task OnActionExecutionAsync(ActionExecutingContext context,
+            ActionExecutionDelegate next)
         {
             await base.OnActionExecutionAsync(context, next);
 
@@ -63,8 +64,6 @@ namespace Ocuda.Promenade.Controllers.Abstract
             }
 
             ViewData[Utility.Keys.ViewData.Title] = pageTitle;
-
-            await next();
         }
 
         protected async Task<string> GetCanonicalUrl()

--- a/src/Promenade.Service/ExternalResourceService.cs
+++ b/src/Promenade.Service/ExternalResourceService.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Ocuda.Promenade.Models.Entities;
 using Ocuda.Promenade.Service.Abstract;
@@ -12,25 +15,69 @@ namespace Ocuda.Promenade.Service
 {
     public class ExternalResourceService : BaseService<ExternalResourceService>
     {
+        private readonly IDistributedCache _cache;
         private readonly IExternalResourceRepository _externalResourceRepository;
 
         public ExternalResourceService(ILogger<ExternalResourceService> logger,
             IDateTimeProvider dateTimeProvider,
+            IDistributedCache cache,
             IExternalResourceRepository externalResourceRepository)
             : base(logger, dateTimeProvider)
         {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
             _externalResourceRepository = externalResourceRepository
                 ?? throw new ArgumentNullException(nameof(externalResourceRepository));
         }
 
-        public async Task<ICollection<ExternalResource>> GetAllAsync()
+        public async Task<ICollection<ExternalResource>> GetAllAsync(bool forceReload)
         {
-            return await GetAllAsync(null);
+            return await GetAllAsync(null, forceReload);
         }
 
-        public async Task<ICollection<ExternalResource>> GetAllAsync(ExternalResourceType? type)
+        public async Task<ICollection<ExternalResource>> GetAllAsync(ExternalResourceType? type,
+            bool forceReload)
         {
-            return await _externalResourceRepository.GetAllAsync(type);
+            long start = Stopwatch.GetTimestamp();
+            var cacheKey = Utility.Keys.Cache.PromExternalResources;
+            ICollection<ExternalResource> resources = null;
+            if (!forceReload)
+            {
+                string cachedResources = await _cache.GetStringAsync(cacheKey);
+                if (!string.IsNullOrEmpty(cachedResources))
+                {
+                    try
+                    {
+                        resources = JsonSerializer
+                            .Deserialize<ICollection<ExternalResource>>(cachedResources);
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Error deserializing external resources from cache: {ErrorMessage}",
+                            ex.Message);
+                    }
+                }
+            }
+
+            if (resources == null)
+            {
+                resources = await _externalResourceRepository.GetAllAsync(type);
+
+                string resToCache = JsonSerializer.Serialize(resources);
+
+                await _cache.SetStringAsync(cacheKey,
+                    resToCache,
+                    new DistributedCacheEntryOptions
+                    {
+                        SlidingExpiration = new TimeSpan(1, 0, 0)
+                    });
+                _logger.LogDebug("Cache miss for {CacheKey}, caching {Length} characters in {Elapsed} ms",
+                    cacheKey,
+                    resToCache.Length,
+                    (Stopwatch.GetTimestamp() - start) * 1000 / (double)Stopwatch.Frequency);
+            }
+
+            return resources;
         }
     }
 }

--- a/src/Promenade.Service/NavigationService.cs
+++ b/src/Promenade.Service/NavigationService.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Text.Json;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Ocuda.Promenade.Models.Entities;
 using Ocuda.Promenade.Service.Abstract;
@@ -11,16 +15,19 @@ namespace Ocuda.Promenade.Service
 {
     public class NavigationService : BaseService<NavigationService>
     {
+        private readonly IDistributedCache _cache;
         private readonly LanguageService _languageService;
         private readonly INavigationRepository _navigationRepository;
         private readonly INavigationTextRepository _navigationTextRepository;
 
         public NavigationService(ILogger<NavigationService> logger,
             IDateTimeProvider dateTimeProvider,
+            IDistributedCache cache,
             LanguageService languageService,
             INavigationRepository navigationRepository,
             INavigationTextRepository navigationTextRepository) : base(logger, dateTimeProvider)
         {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
             _languageService = languageService
                 ?? throw new ArgumentNullException(nameof(languageService));
             _navigationRepository = navigationRepository
@@ -31,14 +38,65 @@ namespace Ocuda.Promenade.Service
 
         public async Task<Navigation> GetNavigation(int navigationId)
         {
+            return await GetNavigation(navigationId, false);
+        }
+
+        public async Task<Navigation> GetNavigation(int navigationId, bool forceReload)
+        {
+            long start = Stopwatch.GetTimestamp();
             var defaultLanguageId = await _languageService.GetDefaultLanguageIdAsync();
-            var nav = await _navigationRepository.FindAsync(navigationId);
-            if (nav.NavigationTextId != null)
+
+            Navigation nav = null;
+
+            var cacheKey = string.Format(CultureInfo.InvariantCulture,
+                Utility.Keys.Cache.PromNavLang,
+                navigationId,
+                defaultLanguageId);
+
+            if (!forceReload)
             {
-                nav.NavigationText = await _navigationTextRepository
-                    .FindAsync((int)nav.NavigationTextId, defaultLanguageId);
+                string cachedNav = await _cache.GetStringAsync(cacheKey);
+
+                if (!string.IsNullOrEmpty(cachedNav))
+                {
+                    try
+                    {
+                        nav = JsonSerializer.Deserialize<Navigation>(cachedNav);
+                    }
+                    catch (JsonException ex)
+                    {
+                        _logger.LogWarning(ex,
+                            "Error deserializing navigation {NavigationId} language {LanguageId} from cache: {ErrorMessage}",
+                            navigationId,
+                            defaultLanguageId,
+                            ex.Message);
+                    }
+                }
             }
-            nav.Navigations = await GetNavigationChildren(navigationId, defaultLanguageId);
+
+            if (nav == null)
+            {
+                nav = await _navigationRepository.FindAsync(navigationId);
+                if (nav.NavigationTextId != null)
+                {
+                    nav.NavigationText = await _navigationTextRepository
+                        .FindAsync((int)nav.NavigationTextId, defaultLanguageId);
+                }
+                nav.Navigations = await GetNavigationChildren(navigationId, defaultLanguageId);
+
+                string navToCache = JsonSerializer.Serialize(nav);
+                await _cache.SetStringAsync(cacheKey,
+                    navToCache,
+                    new DistributedCacheEntryOptions
+                    {
+                        SlidingExpiration = new TimeSpan(1, 0, 0)
+                    });
+                _logger.LogDebug("Cache miss for {CacheKey}, caching {Length} characters in {Elapsed} ms",
+                    cacheKey,
+                    navToCache.Length,
+                    (Stopwatch.GetTimestamp() - start) * 1000 / (double)Stopwatch.Frequency);
+            }
+
             return nav;
         }
 

--- a/src/Promenade.Web/Program.cs
+++ b/src/Promenade.Web/Program.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using System.Reflection;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Ocuda.Utility.Keys;
 using Serilog;
 
 namespace Ocuda.Promenade.Web
@@ -18,14 +18,14 @@ namespace Ocuda.Promenade.Web
             using var webHost = CreateHostBuilder(args).Build();
             var config = (IConfiguration)webHost.Services.GetService(typeof(IConfiguration));
 
-            var instance = string.IsNullOrEmpty(config[Utility.Keys.Configuration.OcudaInstance])
+            var instance = string.IsNullOrEmpty(config[Configuration.OcudaInstance])
                 ? "n/a"
-                : config[Utility.Keys.Configuration.OcudaInstance];
+                : config[Configuration.OcudaInstance];
 
             var version = Utility.Helpers.VersionHelper.GetVersion();
 
             Log.Logger = Utility.Logging.Configuration.Build(config).CreateLogger();
-            Log.Warning("{Product} v{Version} instance {Instance} starting up",
+            Log.Information("{Product} v{Version} instance {Instance} starting up",
                 Product,
                 version,
                 instance);
@@ -38,6 +38,26 @@ namespace Ocuda.Promenade.Web
 
             try
             {
+                if (string.IsNullOrEmpty(config[Configuration.OcudaRuntimeRedisCacheConfiguration]))
+                {
+                    Log.Information("{Product} distributed cache: in memory",
+                        Product);
+                }
+                else
+                {
+                    Log.Information("{Product} distributed cache: Redis configuration {RedisConfiguration} instance {RedisInstance}",
+                        Product,
+                        config[Configuration.OcudaRuntimeRedisCacheConfiguration],
+                        config[Configuration.OcudaRuntimeRedisCacheInstance]);
+                }
+
+                if (!string.IsNullOrEmpty(config[Configuration.OcudaRuntimeSessionTimeout]))
+                {
+                    Log.Information("{Product} session timeout configured for {SessionTimeout}",
+                        Product,
+                        config[Configuration.OcudaRuntimeSessionTimeout]);
+                }
+
                 webHost.Run();
                 return 0;
             }

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -40,6 +40,7 @@
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -20,6 +20,7 @@ using Ocuda.Utility.Abstract;
 using Ocuda.Utility.Exceptions;
 using Ocuda.Utility.Keys;
 using Ocuda.Utility.Providers;
+using Serilog;
 using Serilog.Context;
 
 namespace Ocuda.Promenade.Web
@@ -32,12 +33,25 @@ namespace Ocuda.Promenade.Web
         public Startup(IConfiguration configuration,
             IWebHostEnvironment env)
         {
+            if (env == null)
+            {
+                throw new ArgumentNullException(nameof(env));
+            }
+
             _config = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _isDevelopment = env.IsDevelopment();
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability",
+            "CA1506:Avoid excessive class coupling",
+            Justification = "Dependency injection")]
         public void ConfigureServices(IServiceCollection services)
         {
+            if (services == null)
+            {
+                throw new ArgumentNullException(nameof(services));
+            }
+
             services.AddLocalization();
 
             services.Configure<RequestLocalizationOptions>(_ =>
@@ -54,18 +68,52 @@ namespace Ocuda.Promenade.Web
 
             services.TryAddSingleton<IHttpContextAccessor, HttpContextAccessor>();
 
+            // configure distributed cache
+            switch (_config[Configuration.PromenadeDistributedCache])
+            {
+                case "Redis":
+                    string redisConfiguration
+                        = _config[Configuration.PromenadeDistributedCacheRedisConfiguration]
+                        ?? throw new OcudaException("Configuration.PromenadeDistributedCache has Redis selected but Configuration.PromenadeDistributedCacheRedisConfiguration is not set.");
+                    string instanceName = CacheInstance.OcudaPromenade;
+                    if (!instanceName.EndsWith(".", StringComparison.OrdinalIgnoreCase))
+                    {
+                        instanceName += ".";
+                    }
+                    string cacheDiscriminator
+                        = _config[Configuration.PromenadeDistributedCacheInstanceDiscriminator]
+                        ?? string.Empty;
+                    if (!string.IsNullOrEmpty(cacheDiscriminator))
+                    {
+                        instanceName = $"{instanceName}{cacheDiscriminator}.";
+                    }
+                    _config[Configuration.OcudaRuntimeRedisCacheConfiguration]
+                        = redisConfiguration;
+                    _config[Configuration.OcudaRuntimeRedisCacheInstance] = instanceName;
+                    services.AddDistributedRedisCache(_ =>
+                    {
+                        _.Configuration = redisConfiguration;
+                        _.InstanceName = instanceName;
+                    });
+                    break;
+                default:
+                    services.AddDistributedMemoryCache();
+                    break;
+            }
+
+            // database configuration
             string promCs = _config.GetConnectionString("Promenade")
                 ?? throw new OcudaException("ConnectionString:Promenade not configured.");
 
             var provider = _config[Configuration.PromenadeDatabaseProvider];
             if (provider == "SqlServer")
             {
-                services.AddDbContextPool<PromenadeContext, DataProvider.SqlServer.Promenade.Context>(_ =>
-                    _.UseSqlServer(promCs));
+                services.AddDbContextPool<PromenadeContext,
+                    DataProvider.SqlServer.Promenade.Context>(_ => _.UseSqlServer(promCs));
             }
             else
             {
-                throw new OcudaException($"No {Configuration.PromenadeDatabaseProvider} configured.");
+                throw new OcudaException("No Configuration.PromenadeDatabaseProvider configured.");
             }
 
             services.Configure<RouteOptions>(_ =>
@@ -92,7 +140,7 @@ namespace Ocuda.Promenade.Web
                         => factory.Create(typeof(i18n.Resources.Shared));
                 });
             }
-            
+
             services.Configure<RouteOptions>(_ =>
             {
                 _.AppendTrailingSlash = true;
@@ -183,6 +231,16 @@ namespace Ocuda.Promenade.Web
         public void Configure(IApplicationBuilder app,
             Utility.Services.Interfaces.IPathResolverService pathResolver)
         {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+
+            if (pathResolver == null)
+            {
+                throw new ArgumentNullException(nameof(pathResolver));
+            }
+
             // configure error page handling and development IDE linking
             if (_isDevelopment)
             {
@@ -213,7 +271,8 @@ namespace Ocuda.Promenade.Web
             // insert remote address into the log context for each request
             app.Use(async (context, next) =>
             {
-                using (LogContext.PushProperty("RemoteAddress", context.Connection.RemoteIpAddress))
+                using (LogContext.PushProperty("RemoteAddress",
+                    context.Connection.RemoteIpAddress))
                 {
                     await next.Invoke();
                 }
@@ -235,6 +294,11 @@ namespace Ocuda.Promenade.Web
                     = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(contentFilePath),
                 RequestPath = new PathString(contentUrl)
             });
+
+            if (!string.IsNullOrEmpty(_config[Configuration.PromenadeRequestLogging]))
+            {
+                app.UseSerilogRequestLogging();
+            }
 
             app.UseRouting();
 

--- a/src/Promenade.Web/Web.cs
+++ b/src/Promenade.Web/Web.cs
@@ -19,35 +19,23 @@ namespace Ocuda.Promenade.Web
 
         public async Task InitalizeAsync()
         {
-            int stage = 10;
             try
             {
                 var languageService = _scope.ServiceProvider.GetRequiredService<LanguageService>();
                 await languageService.SyncLanguagesAsync();
             }
+            catch (InvalidOperationException ioex)
+            {
+                _log.LogCritical(ioex,
+                    "Error acquiring LanguageService to sync languages in database: {ErrorMessage}",
+                    ioex.Message);
+            }
             catch (Exception ex)
             {
-                bool critical = false;
-                string errorText;
-                switch (stage)
-                {
-                    case 10:
-                        errorText = "Error syncing available languages with database: {Message}";
-                        break;
-                    default:
-                        errorText = "Unknown error during application startup: {Message}";
-                        break;
-                }
-
-                if (critical)
-                {
-                    _log.LogCritical(ex, errorText, ex.Message);
-                    throw;
-                }
-                else
-                {
-                    _log.LogCritical(ex, errorText, ex.Message);
-                }
+                _log.LogCritical(ex,
+                    "Error syncing available languages with database: {ErrorMessage}",
+                    ex.Message);
+                throw;
             }
         }
     }

--- a/src/Promenade.Web/appsettings.json
+++ b/src/Promenade.Web/appsettings.json
@@ -1,4 +1,5 @@
 ﻿{
+  "Promenade.DatabaseProvider": "SqlServer",
   "Promenade.Instance": "Ocuda.Promenade.Web",
-  "Promenade.DatabaseProvider": "SqlServer"
+  "Promenade.RequestLogging": "1"
 }

--- a/src/Utility/Keys/Cache.cs
+++ b/src/Utility/Keys/Cache.cs
@@ -24,5 +24,20 @@
         /// Cached site settings, {0} is the site setting key
         /// </summary>
         public static readonly string OpsSiteSetting = "sitesetting.{0}";
+
+        /// <summary>
+        /// Cached navigation element, {0} is the id of the element, {1} is the language id
+        /// </summary>
+        public static readonly string PromNavLang = "nav.{0}.{1}";
+
+        /// <summary>
+        /// Cached site settings, {0} is the site setting key
+        /// </summary>
+        public static readonly string PromSiteSetting = "sitesetting.{0}";
+
+        /// <summary>
+        /// Cached external resource list
+        /// </summary>
+        public static readonly string PromExternalResources = "externalresources";
     }
 }

--- a/src/Utility/Keys/CacheInstance.cs
+++ b/src/Utility/Keys/CacheInstance.cs
@@ -3,5 +3,6 @@
     public struct CacheInstance
     {
         public static readonly string OcudaOps = "ocuda.ops";
+        public static readonly string OcudaPromenade = "ocuda.prom";
     }
 }

--- a/src/Utility/Keys/Configuration.cs
+++ b/src/Utility/Keys/Configuration.cs
@@ -47,5 +47,14 @@
 
         public static readonly string PromenadeAPIGoogleMaps = "Promenade.API.GoogleMaps";
         public static readonly string PromenadeDatabaseProvider = "Promenade.DatabaseProvider";
+        public static readonly string PromenadeDistributedCache = "Promenade.DistributedCache";
+
+        public static readonly string PromenadeDistributedCacheInstanceDiscriminator
+            = "Promenade.DistributedCacheInstanceDiscriminator";
+
+        public static readonly string PromenadeDistributedCacheRedisConfiguration
+            = "Promenade.DistributedCache.RedisConfiguration";
+
+        public static readonly string PromenadeRequestLogging = "Promenade.RequestLogging";
     }
 }


### PR DESCRIPTION
- Exclude warning about excessive class coupling on DI classes
- Fix error messages for missing configuration values
- Add distributed caching to project (Redis or in-memory)
- Add distributed caching to all LayoutFilter service calls which use the database
- Add debug-level logging of caching information with timing metrics
- Code cleanup
- Add request logging to Promenade (setting "Promenade.RequestLogging")