### PR TITLE
Improve page title suffix; general code fixes

### DIFF
--- a/src/Promenade.Controllers/Abstract/BasePageController.cs
+++ b/src/Promenade.Controllers/Abstract/BasePageController.cs
@@ -49,14 +49,9 @@ namespace Ocuda.Promenade.Controllers.Abstract
                         redirectUrl += Request.QueryString;
                     }
 
-                    if (redirect.IsPermanent)
-                    {
-                        return RedirectPermanent(redirectUrl);
-                    }
-                    else
-                    {
-                        return Redirect(redirectUrl);
-                    }
+                    return redirect.IsPermanent
+                        ? RedirectPermanent(redirectUrl)
+                        : Redirect(redirectUrl);
                 }
 
                 _logger.LogWarning("No {PageType} page or redirect found for stub {stub}: {RequestPath}",

--- a/src/Promenade.Controllers/Filters/LayoutFilter.cs
+++ b/src/Promenade.Controllers/Filters/LayoutFilter.cs
@@ -89,6 +89,9 @@ namespace Ocuda.Promenade.Controllers.Filters
                 .Where(_ => _.Type == ExternalResourceType.JS)
                 .Select(_ => _.Url).ToList();
 
+            context.HttpContext.Items[ItemKey.PageTitleSuffix] = await _siteSettingService
+                .GetSettingStringAsync(SiteSetting.Site.PageTitleSuffix, forceReload);
+
             var topNavigationId = await _siteSettingService
                 .GetSettingIntAsync(SiteSetting.Site.NavigationIdTop, forceReload);
 

--- a/src/Promenade.Controllers/ItemKey.cs
+++ b/src/Promenade.Controllers/ItemKey.cs
@@ -12,6 +12,7 @@
         public const string L10n = "L10n";
         public const string LeftNavigation = "LeftNavigation";
         public const string MiddleNavigation = "MiddleNavigation";
+        public const string PageTitleSuffix = "PageTitle";
         public const string TopNavigation = "TopNavigation";
     }
 }

--- a/src/Promenade.Controllers/LocationsController.cs
+++ b/src/Promenade.Controllers/LocationsController.cs
@@ -291,8 +291,11 @@ namespace Ocuda.Promenade.Controllers
             viewModel.Location.DescriptionSegment = await _segmentService
                 .GetSegmentTextBySegmentIdAsync(viewModel.Location.DescriptionSegmentId);
 
-            viewModel.Location.DescriptionSegment.Text = CommonMarkConverter
-                .Convert(viewModel.Location.DescriptionSegment.Text);
+            if (viewModel.Location.DescriptionSegment?.Text.Length > 0)
+            {
+                viewModel.Location.DescriptionSegment.Text = CommonMarkConverter
+                    .Convert(viewModel.Location.DescriptionSegment.Text);
+            }
 
             viewModel.Location.LocationHours
                 = await _locationService.GetFormattedWeeklyHoursAsync(viewModel.Location.Id);

--- a/src/Promenade.Web/Views/Locations/LocationDetails.cshtml
+++ b/src/Promenade.Web/Views/Locations/LocationDetails.cshtml
@@ -59,11 +59,14 @@
 
     <h2>Library Information</h2>
 
-    <div class="row prom-feature-segment">
-        <div class="col-12">
-            @Html.Raw(Model.Location.DescriptionSegment.Text)
+    @if (Model.Location.DescriptionSegment?.Text?.Length > 0)
+    {
+        <div class="row prom-feature-segment">
+            <div class="col-12">
+                @Html.Raw(Model.Location.DescriptionSegment.Text)
+            </div>
         </div>
-    </div>
+    }
 
     <div class="row prom-features">
         <div class="col-4 col-md-3 col-lg-2 mb-2">

--- a/src/Promenade.Web/Views/Shared/_Layout.cshtml
+++ b/src/Promenade.Web/Views/Shared/_Layout.cshtml
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData[Ocuda.Utility.Keys.ViewData.Title]</title>
-    <link rel="shortcut icon" href="#" />
     @RenderSection("metadata", required: false)
     @{
         var googleAnalyticsTrackingCode = Context.Items[Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode] as string;
@@ -231,7 +230,7 @@
     {
         foreach (var jsUrl in (List<string>)Context.Items[ItemKey.ExternalJS])
         {
-            <script src="@jsUrl" asp-append-version="true"></script>
+            <script src="@jsUrl"></script>
         }
     }
     @RenderSection("Scripts", required: false)


### PR DESCRIPTION
- Include page title suffix in HttpContext.Items
- Change page title approach to use OnActionExectued
- Cache no value properly for site settings
- Fix location display page if description segment is blank
- Remove shortcut icon link causing double page loads in Chrome
- Remove non-fucntional asp-append-version for external scripts