### PR TITLE
Move Promenade DPK to context; reduce logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ## Unreleased
 ### Added
+- Move Promenade Data Protection Key from file system storage to database storage
+
+### Changed
+- Default to only logging Warnings for Microsoft and System namespaces
+
+## 1.0.0
+### Added
+- Everything (initial release)

--- a/src/Ops.Data/PromenadeContext.cs
+++ b/src/Ops.Data/PromenadeContext.cs
@@ -1,11 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Ocuda.Promenade.Models.Entities;
 
 namespace Ocuda.Ops.Data
 {
-    public abstract class PromenadeContext : Utility.Data.DbContextBase, IMigratableContext
+    public abstract class PromenadeContext
+        : Utility.Data.DbContextBase, IMigratableContext, IDataProtectionKeyContext
     {
         protected PromenadeContext(DbContextOptions options) : base(options) { }
 
@@ -49,6 +51,7 @@ namespace Ocuda.Ops.Data
 
         public DbSet<Category> Categories { get; set; }
         public DbSet<CategoryText> CategoryTexts { get; set; }
+        public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
         public DbSet<Emedia> Emedia { get; set; }
         public DbSet<EmediaCategory> EmediaCategories { get; set; }
         public DbSet<EmediaText> EmediaTexts { get; set; }

--- a/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200214184201_prom_v1.0.0.1.Designer.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200214184201_prom_v1.0.0.1.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ocuda.Ops.DataProvider.SqlServer.Promenade;
 
 namespace Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20200214184201_prom_v1.0.0.1")]
+    partial class prom_v1001
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200214184201_prom_v1.0.0.1.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200214184201_prom_v1.0.0.1.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations
+{
+    public partial class prom_v1001 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DataProtectionKeys",
+                columns: table => new
+                {
+                    Id = table.Column<int>(nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    FriendlyName = table.Column<string>(nullable: true),
+                    Xml = table.Column<string>(nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DataProtectionKeys", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DataProtectionKeys");
+        }
+    }
+}

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.0</FileVersion>
+    <FileVersion>1.0.0.1</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Data/Promenade.Data.csproj
+++ b/src/Promenade.Data/Promenade.Data.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/Promenade.Data/PromenadeContext.cs
+++ b/src/Promenade.Data/PromenadeContext.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Ocuda.Promenade.Models.Entities;
 
 namespace Ocuda.Promenade.Data
 {
-    public abstract class PromenadeContext : Utility.Data.DbContextBase
+    public abstract class PromenadeContext : Utility.Data.DbContextBase, IDataProtectionKeyContext
     {
         protected PromenadeContext(DbContextOptions options) : base(options) { }
 
@@ -34,6 +35,7 @@ namespace Ocuda.Promenade.Data
         // Read-Only
         public DbSet<Category> Categories { get; }
         public DbSet<CategoryText> CategoryTexts { get; }
+        public DbSet<DataProtectionKey> DataProtectionKeys { get; set; }
         public DbSet<Emedia> Emedia { get; set; }
         public DbSet<EmediaCategory> EmediaCategories { get; set; }
         public DbSet<EmediaText> EmediaTexts { get; }

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0</FileVersion>
+    <FileVersion>1.0.0.1</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>
@@ -39,6 +39,8 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.435" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="3.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.2.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Localization;
@@ -114,6 +115,8 @@ namespace Ocuda.Promenade.Web
             {
                 throw new OcudaException("No Configuration.PromenadeDatabaseProvider configured.");
             }
+
+            services.AddDataProtection().PersistKeysToDbContext<PromenadeContext>();
 
             services.Configure<RouteOptions>(_ =>
                 _.ConstraintMap.Add("cultureConstraint", typeof(CultureRouteConstraint)));

--- a/src/Promenade.Web/appsettings.Development.json
+++ b/src/Promenade.Web/appsettings.Development.json
@@ -2,14 +2,5 @@
   "ConnectionStrings": {
     "Promenade": "Server=(LocalDb)\\MSSQLLocalDB;Database=Ocuda.Promenade;Trusted_Connection=True;MultipleActiveResultSets=True"
   },
-  "Ocuda.Instance": "promenade.dev",
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Debug",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
-    }
-  }
+  "Ocuda.Instance": "promenade.dev"
 }

--- a/src/Promenade.Web/appsettings.json
+++ b/src/Promenade.Web/appsettings.json
@@ -1,5 +1,14 @@
 ﻿{
   "Ocuda.UrlSharedContent": "/assets",
   "Promenade.DatabaseProvider": "SqlServer",
-  "Promenade.RequestLogging": "1"
+  "Promenade.RequestLogging": "1",
+  "Serilog": {
+    "MinimumLevel": {
+      "Default": "Debug",
+      "Override": {
+        "Microsoft": "Warning",
+        "System": "Warning"
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Move Promenade Data Protection Key into PromenadeContext
- Default Promenade logging for Microsoft and System namespaces to warning