### PR TITLE
Add ability to require fields based on subject

### DIFF
--- a/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.Designer.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Ocuda.Ops.DataProvider.SqlServer.Promenade;
 
 namespace Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations
 {
     [DbContext(typeof(Context))]
-    partial class ContextModelSnapshot : ModelSnapshot
+    [Migration("20200507204459_prom_v1.0.0.32")]
+    partial class prom_v10032
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations
+{
+    public partial class prom_v10032 : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "RequireComments",
+                table: "ScheduleRequestSubject",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RequireEmail",
+                table: "ScheduleRequestSubject",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<int>(
+                name: "SegmentId",
+                table: "ScheduleRequestSubject",
+                nullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "ScheduleRequest",
+                maxLength: 255,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(255)",
+                oldMaxLength: 255);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RequireComments",
+                table: "ScheduleRequestSubject");
+
+            migrationBuilder.DropColumn(
+                name: "RequireEmail",
+                table: "ScheduleRequestSubject");
+
+            migrationBuilder.DropColumn(
+                name: "SegmentId",
+                table: "ScheduleRequestSubject");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Notes",
+                table: "ScheduleRequest",
+                type: "nvarchar(255)",
+                maxLength: 255,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldMaxLength: 255,
+                oldNullable: true);
+        }
+    }
+}

--- a/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Migrations/20200507204459_prom_v1.0.0.32.cs
@@ -31,6 +31,8 @@ namespace Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations
                 oldClrType: typeof(string),
                 oldType: "nvarchar(255)",
                 oldMaxLength: 255);
+
+            migrationBuilder.Sql(@"UPDATE [ScheduleRequestSubject] SET [RequireComments] = 1;");
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <AssemblyName>Ocuda.Ops.Web</AssemblyName>
-    <AssemblyVersion>1.0.0.31</AssemblyVersion>
+    <AssemblyVersion>1.0.0.32</AssemblyVersion>
     <Authors>Maricopa County Library District Web developers</Authors>
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.31</FileVersion>
+    <FileVersion>1.0.0.32</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Controllers/HelpController.cs
+++ b/src/Promenade.Controllers/HelpController.cs
@@ -259,9 +259,6 @@ namespace Ocuda.Promenade.Controllers
             }
             else
             {
-                TempData[TempDataDateTime] = viewModel.ScheduleRequest.RequestedTime;
-                TempData[TempDataSubjectId] = viewModel.ScheduleRequest.ScheduleRequestSubjectId;
-
                 return await DisplayScheduleDetailsFormAsync(viewModel);
             }
         }

--- a/src/Promenade.Controllers/ViewModels/Help/ScheduleDetailsViewModel.cs
+++ b/src/Promenade.Controllers/ViewModels/Help/ScheduleDetailsViewModel.cs
@@ -1,0 +1,61 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Ocuda.Promenade.Models.Entities;
+using Ocuda.Utility.Helpers;
+
+namespace Ocuda.Promenade.Controllers.ViewModels.Help
+{
+    public class ScheduleDetailsViewModel
+    {
+        public SegmentText SegmentText { get; set; }
+
+        public string EmailRequiredMessage { get; set; }
+        public string NotesRequiredMessage { get; set; }
+
+        [Display(Name = "Requested date and time")]
+        public string DisplayTime
+        {
+            get
+            {
+                return ScheduleRequest.RequestedTime.ToShortDateString()
+                    + " at "
+                    + ScheduleRequest.RequestedTime.ToShortTimeString();
+            }
+        }
+
+        [Display(Name = "Subject")]
+        public string DisplaySubject { get; set; }
+
+        public bool ForceReload { get; set; }
+
+        public ScheduleRequest ScheduleRequest { get; set; }
+
+        public SelectListItem[] Languages = new SelectListItem[]
+        {
+            new SelectListItem
+            {
+                 Text = "English",
+                 Value = "English"
+            },
+            new SelectListItem
+            {
+                Text = "español",
+                Value = "español"
+            }
+        };
+
+        [Display(Name = "Phone")]
+        [MaxLength(255)]
+        [Required]
+        public string ScheduleRequestPhone { get; set; }
+
+        public string FormattedPhone
+        {
+            get
+            {
+                return TextFormattingHelper
+                    .FormatPhone(ScheduleRequest?.ScheduleRequestTelephone?.Phone);
+            }
+        }
+    }
+}

--- a/src/Promenade.Controllers/ViewModels/Help/ScheduleViewModel.cs
+++ b/src/Promenade.Controllers/ViewModels/Help/ScheduleViewModel.cs
@@ -2,7 +2,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc.Rendering;
 using Ocuda.Promenade.Models.Entities;
-using Ocuda.Utility.Helpers;
 
 namespace Ocuda.Promenade.Controllers.ViewModels.Help
 {
@@ -10,43 +9,17 @@ namespace Ocuda.Promenade.Controllers.ViewModels.Help
     {
         public SegmentText SegmentText { get; set; }
         public IEnumerable<SelectListItem> Subjects { get; set; }
-        public ScheduleRequest ScheduleRequest { get; set; }
 
-        public SelectListItem[] Languages = new SelectListItem[]
-        {
-            new SelectListItem
-            {
-                 Text = "English",
-                 Value = "English"
-            },
-            new SelectListItem
-            {
-                Text = "español",
-                Value = "español"
-            }
-        };
-
+        [Required]
         [Display(Name = "Requested date")]
         public System.DateTime RequestedDate { get; set; }
 
+        [Required]
         [Display(Name = "Requested time")]
         public System.DateTime RequestedTime { get; set; }
 
-        [Display(Name = "Subject")]
-        public string ScheduleRequestSubject { get; set; }
-
-        [Display(Name = "Phone")]
-        [MaxLength(255)]
         [Required]
-        public string ScheduleRequestPhone { get; set; }
-
-        public string FormattedPhone
-        {
-            get
-            {
-                return TextFormattingHelper
-                    .FormatPhone(ScheduleRequest?.ScheduleRequestTelephone?.Phone);
-            }
-        }
+        [Display(Name = "Subject")]
+        public int SubjectId { get; set; }
     }
 }

--- a/src/Promenade.Models/Entities/ScheduleRequest.cs
+++ b/src/Promenade.Models/Entities/ScheduleRequest.cs
@@ -33,7 +33,6 @@ namespace Ocuda.Promenade.Models.Entities
         [MaxLength(255)]
         public string Language { get; set; }
 
-        [Required]
         [MaxLength(255)]
         [Display(Name = "How can we help?")]
         public string Notes { get; set; }

--- a/src/Promenade.Models/Entities/ScheduleRequestSubject.cs
+++ b/src/Promenade.Models/Entities/ScheduleRequestSubject.cs
@@ -11,5 +11,10 @@ namespace Ocuda.Promenade.Models.Entities
         [MaxLength(255)]
         [Required]
         public string Subject { get; set; }
+
+        public int? SegmentId { get; set; }
+
+        public bool RequireEmail { get; set; }
+        public bool RequireComments { get; set; }
     }
 }

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <AssemblyName>Ocuda.Promenade.Web</AssemblyName>
-    <AssemblyVersion>1.0.0.31</AssemblyVersion>
+    <AssemblyVersion>1.0.0.32</AssemblyVersion>
     <Authors>Maricopa County Library District Web developers</Authors>
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.31</FileVersion>
+    <FileVersion>1.0.0.32</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Views/Help/NoSchedule.cshtml
+++ b/src/Promenade.Web/Views/Help/NoSchedule.cshtml
@@ -1,12 +1,12 @@
-﻿@model Ocuda.Promenade.Controllers.ViewModels.Help.ScheduleViewModel
+﻿@model Ocuda.Promenade.Models.Entities.SegmentText
 
-@if (Model?.SegmentText != null)
+@if (Model != null)
 {
-    if (!string.IsNullOrEmpty(Model.SegmentText.Header))
+    if (!string.IsNullOrEmpty(Model.Header))
     {
-        <h1>@Model.SegmentText.Header</h1>
+        <h1>@Model.Header</h1>
     }
-    @Html.Raw(Model.SegmentText.Text)
+    @Html.Raw(Model.Text)
 }
 else
 {

--- a/src/Promenade.Web/Views/Help/Schedule.cshtml
+++ b/src/Promenade.Web/Views/Help/Schedule.cshtml
@@ -22,23 +22,14 @@ else
                    type="time"
                    step="1800"
                    formgroup />
-            <input asp-for="ScheduleRequest.Name" formgroup />
-            <input asp-for="ScheduleRequestPhone"
-                   type="tel"
-                   placeholder="###-###-####"
-                   formgroup />
-            <input asp-for="ScheduleRequest.Email"
-                   formgroup
-                   type="email" />
-            <select asp-for="ScheduleRequest.ScheduleRequestSubjectId"
+            <select asp-for="SubjectId"
                     asp-items="Model.Subjects" formgroup></select>
-            <select asp-for="ScheduleRequest.Language"
-                    asp-items="Model.Languages" formgroup></select>
-            <textarea asp-for="ScheduleRequest.Notes"
-                      maxlength="255"
-                      formgroup />
-            <div class="offset-md-3">
-                <input type="submit" class="btn btn-outline-success m-2" />
+            <div>
+                <button type="submit"
+                        class="btn btn-outline-dark m-2 btn-lg float-right">
+                    Next
+                    <span class="fas fa-chevron-right"></span>
+                </button>
             </div>
         </form>
     </div>

--- a/src/Promenade.Web/Views/Help/ScheduleDetails.cshtml
+++ b/src/Promenade.Web/Views/Help/ScheduleDetails.cshtml
@@ -1,0 +1,51 @@
+﻿@model Ocuda.Promenade.Controllers.ViewModels.Help.ScheduleDetailsViewModel
+
+@if (Model?.SegmentText != null)
+{
+    if (!string.IsNullOrEmpty(Model.SegmentText.Header))
+    {
+        <h1>@Model.SegmentText.Header</h1>
+    }
+    @Html.Raw(Model.SegmentText.Text)
+}
+else
+{
+    <h1>Schedule your time</h1>
+}
+<div class="row">
+    <div class="col-12">
+        <form method="post" action="@Url.Action("ScheduleDetails", "Help")"
+              type="date"
+              formgroup>
+            <input asp-for="DisplayTime" formgroup readonly />
+            <input asp-for="DisplaySubject" formgroup readonly />
+            <input asp-for="ScheduleRequest.Name" formgroup />
+            <input asp-for="ScheduleRequestPhone"
+                   type="tel"
+                   placeholder="###-###-####"
+                   formgroup />
+            <input asp-for="ScheduleRequest.Email"
+                   formgroup
+                   formgroup-val-required="@Model.EmailRequiredMessage"
+                   type="email" />
+            <select asp-for="ScheduleRequest.Language"
+                    asp-items="Model.Languages" formgroup></select>
+            <textarea asp-for="ScheduleRequest.Notes"
+                      maxlength="255"
+                      formgroup-val-required="@Model.NotesRequiredMessage"
+                      formgroup />
+            <div>
+                <a href="@Url.Action("Schedule", "Help")"
+                   class="btn btn-outline-dark m-2 btn-lg float-left">
+                    <span class="fas fa-chevron-left"></span>
+                    Back
+                </a>
+                <button type="submit"
+                        class="btn btn-outline-success m-2 btn-lg float-right">
+                    <span class="far fa-check-circle"></span>
+                    Submit
+                </button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/Promenade.Web/Views/Help/Scheduled.cshtml
+++ b/src/Promenade.Web/Views/Help/Scheduled.cshtml
@@ -1,4 +1,4 @@
-﻿@model Ocuda.Promenade.Controllers.ViewModels.Help.ScheduleViewModel
+﻿@model Ocuda.Promenade.Controllers.ViewModels.Help.ScheduleDetailsViewModel
 
 @if (Model?.SegmentText != null)
 {
@@ -16,8 +16,8 @@ else
 <p class="lead">Here are the details:</p>
 
 <div class="row">
-    <div class="col-md-3 text-md-right"><strong>Requested time</strong></div>
-    <div class="col-md-9">@Model.ScheduleRequest.RequestedTime</div>
+    <div class="col-md-3 text-md-right"><strong>Requested date and time</strong></div>
+    <div class="col-md-9">@Model.DisplayTime</div>
 </div>
 <div class="row mt-2">
     <div class="col-md-3 text-md-right"><strong>Name</strong></div>
@@ -38,7 +38,7 @@ else
 
 <div class="row mt-2">
     <div class="col-md-3 text-md-right"><strong>Subject</strong></div>
-    <div class="col-md-9">@Model.ScheduleRequestSubject</div>
+    <div class="col-md-9">@Model.DisplaySubject</div>
 </div>
 <div class="row mt-2">
     <div class="col-md-3 text-md-right"><strong>Language</strong></div>

--- a/src/Utility/Keys/Cache.cs
+++ b/src/Utility/Keys/Cache.cs
@@ -109,5 +109,10 @@
         /// Cached emedia categories
         /// </summary>
         public static readonly string PromEmediaCategories = "emediacategories";
+
+        /// <summary>
+        /// Cached schedule subjects
+        /// </summary>
+        public static readonly string PromScheduleSubjects = "schedulesubjects";
     }
 }

--- a/src/Utility/Keys/Configuration.cs
+++ b/src/Utility/Keys/Configuration.cs
@@ -2,6 +2,7 @@
 {
     public struct Configuration
     {
+        public static readonly string OcudaCookieName = "Ocuda.CookieName";
         public static readonly string OcudaErrorControllerName = "Ocuda.ErrorControllerName";
         public static readonly string OcudaFileShared = "Ocuda.FileShared";
         public static readonly string OcudaInstance = "Ocuda.Instance";
@@ -61,5 +62,8 @@
             = "Promenade.DistributedCache.RedisConfiguration";
 
         public static readonly string PromenadeRequestLogging = "Promenade.RequestLogging";
+
+        public static readonly string PromenadeSessionTimeoutMinutes
+            = "Promenade.SessionTimeoutMinutes";
     }
 }

--- a/src/Utility/TagHelpers/FormGroupTagHelper.cs
+++ b/src/Utility/TagHelpers/FormGroupTagHelper.cs
@@ -33,6 +33,8 @@ namespace Ocuda.Utility.TagHelpers
         private const string defaultValidationMessageClass = "validation-message text-danger";
         private const string validationIgnoreClass = "validation-ignore";
 
+        private const string requiredFieldClass = "fas fa-asterisk fa-xs d-inline-block ml-2 text-danger oc-required-field-marker";
+
         private const string dateTimeGroupClass = "input-group date";
         private const string dateTimePickerClass = "datetimepicker";
         private const string dateTimeDatePickerClass = "datepicker";
@@ -85,7 +87,7 @@ namespace Ocuda.Utility.TagHelpers
             TagHelperOutput labelElement = null;
             if (!HideLabel)
             {
-                labelElement = await CreateLabelElement(context);
+                labelElement = await CreateLabelElement(context, output);
             }
             TagHelperOutput inputElement = await CreateInputElement(output);
             TagHelperOutput validationMessageElement
@@ -118,7 +120,8 @@ namespace Ocuda.Utility.TagHelpers
             output.Content.SetHtmlContent(formGroupDiv);
         }
 
-        private async Task<TagHelperOutput> CreateLabelElement(TagHelperContext context)
+        private async Task<TagHelperOutput> CreateLabelElement(TagHelperContext context,
+            TagHelperOutput output)
         {
             var labelTagHelper =
                 new LabelTagHelper(_htmlGenerator)
@@ -154,6 +157,14 @@ namespace Ocuda.Utility.TagHelpers
                 labelOutput.Content.AppendHtml(tooltip.RenderSelfClosingTag());
             }
 
+            if (output.Attributes.ContainsName("data-val-required")
+                || output.Attributes.ContainsName("formgroup-val-required"))
+            {
+                var icon = new TagBuilder("span");
+                icon.AddCssClass(requiredFieldClass);
+
+                labelOutput.Content.AppendHtml(icon.RenderSelfClosingTag());
+            }
             return labelOutput;
         }
 
@@ -230,6 +241,13 @@ namespace Ocuda.Utility.TagHelpers
                 pickerGroup.Attributes.Add("data-target-input", dateTimeTargetInput);
                 inputOutput.PreElement.AppendHtml(pickerGroup.RenderStartTag());
                 inputOutput.PostElement.AppendHtml(pickerGroup.RenderEndTag());
+            }
+
+            if (inputOutput.Attributes.ContainsName("formgroup-val-required"))
+            {
+                var tagValue = inputOutput.Attributes["formgroup-val-required"];
+                inputOutput.Attributes.Add("data-val-required", tagValue.Value);
+                inputOutput.Attributes.Remove(tagValue);
             }
 
             return inputOutput;


### PR DESCRIPTION
- Add email/notes requirement on a per-subject basis
- Improve TagHelper to show asterisks on required fields
- Improve TagHelper to handle manual required field messages
- Change schedule process to be two steps
- Enable sessions in distributed cache for Promenade