### PR TITLE
Fix appointment back button; cache email templates

### DIFF
--- a/src/Ops.Controllers/ViewModels/Contact/ScheduleDetailViewModel.cs
+++ b/src/Ops.Controllers/ViewModels/Contact/ScheduleDetailViewModel.cs
@@ -28,5 +28,6 @@ namespace Ocuda.Ops.Controllers.ViewModels.Contact
         public ScheduleLog AddLog { get; set; }
         public IEnumerable<SelectListItem> CallDispositions { get; set; }
         public string FinishMessage { get; set; }
+        public string RequestedDate { get; set; }
     }
 }

--- a/src/Ops.Service/Abstract/BaseService.cs
+++ b/src/Ops.Service/Abstract/BaseService.cs
@@ -7,16 +7,14 @@ using Ocuda.Utility.Keys;
 
 namespace Ocuda.Ops.Service.Abstract
 {
-    public abstract class BaseService<TService>
+    public abstract class BaseService<TService> : Utility.Services.OcudaBaseService<TService>
     {
-        protected readonly ILogger<TService> _logger;
-
         private readonly IHttpContextAccessor _httpContextAccessor;
 
         protected BaseService(ILogger<TService> logger,
             IHttpContextAccessor httpContextAccessor)
+            : base(logger)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _httpContextAccessor = httpContextAccessor
                 ?? throw new ArgumentNullException(nameof(httpContextAccessor));
         }

--- a/src/Ops.Web/Areas/Contact/Views/Schedule/Details.cshtml
+++ b/src/Ops.Web/Areas/Contact/Views/Schedule/Details.cshtml
@@ -113,6 +113,10 @@
                     Cancel Appointment
                 </button>
             }
+            <a class="btn btn-outline-dark mt-2 mb-1 mr-4 float-right"
+               asp-controller="Schedule"
+               asp-action="@(nameof(Ocuda.Ops.Controllers.Areas.Contact.ScheduleController.Index))"
+               asp-route-requestedDate="@Model.RequestedDate">Back</a>
         </div>
     </div>
 

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <AssemblyName>Ocuda.Ops.Web</AssemblyName>
-    <AssemblyVersion>1.0.0.58</AssemblyVersion>
+    <AssemblyVersion>1.0.0.59</AssemblyVersion>
     <Authors>Maricopa County Library District Web developers</Authors>
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.58</FileVersion>
+    <FileVersion>1.0.0.59</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Service/Abstract/BaseService.cs
+++ b/src/Promenade.Service/Abstract/BaseService.cs
@@ -1,24 +1,20 @@
 ﻿using System;
-using System.Text.Json;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Ocuda.Utility.Abstract;
 
 namespace Ocuda.Promenade.Service.Abstract
 {
-    public abstract class BaseService<TService>
+    public abstract class BaseService<TService> : Utility.Services.OcudaBaseService<TService>
     {
-        protected TimeSpan CacheSlidingExpiration { get; set; }
-
-        protected readonly ILogger<TService> _logger;
         protected readonly IDateTimeProvider _dateTimeProvider;
+
+        protected TimeSpan CacheSlidingExpiration { get; set; }
 
         protected BaseService(ILogger<TService> logger,
             IDateTimeProvider dateTimeProvider)
+            : base(logger)
         {
-            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _dateTimeProvider = dateTimeProvider
                 ?? throw new ArgumentNullException(nameof(dateTimeProvider));
 
@@ -44,62 +40,6 @@ namespace Ocuda.Promenade.Service.Abstract
             }
 
             return cachePagesInHours;
-        }
-
-        protected async Task<T> GetFromCacheAsync<T>(IDistributedCache cache, string cacheKey)
-            where T : class
-        {
-            if (cache == null || string.IsNullOrEmpty(cacheKey))
-            {
-                return null;
-            }
-
-            string cachedJson = await cache.GetStringAsync(cacheKey);
-
-            if (!string.IsNullOrEmpty(cachedJson))
-            {
-                _logger.LogTrace("Cache hit for {CacheKey}", cacheKey);
-
-                try
-                {
-                    return JsonSerializer.Deserialize<T>(cachedJson);
-                }
-                catch (JsonException ex)
-                {
-                    _logger.LogWarning(ex,
-                        "Error deserializing {Type} with key {CacheKey} from cache: {ErrorMessage}",
-                        typeof(T),
-                        cacheKey,
-                        ex.Message);
-                    await cache.RemoveAsync(cacheKey);
-                }
-            }
-            return null;
-        }
-
-        protected async Task SaveToCacheAsync<T>(IDistributedCache cache,
-            string cacheKey,
-            T item,
-            int? cacheDuration) where T : class
-        {
-            if (cacheDuration == null || string.IsNullOrEmpty(cacheKey) || item == null)
-            {
-                return;
-            }
-
-            string itemJson = JsonSerializer.Serialize(item);
-
-            await cache.SetStringAsync(cacheKey,
-                itemJson,
-                new DistributedCacheEntryOptions
-                {
-                    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours((int)cacheDuration)
-                });
-
-            _logger.LogDebug("Cache miss for {CacheKey}, caching {Type}: {Length} characters",
-                cacheKey,
-                typeof(T),
-                itemJson.Length);
         }
     }
 }

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <AssemblyName>Ocuda.Promenade.Web</AssemblyName>
-    <AssemblyVersion>1.0.0.58</AssemblyVersion>
+    <AssemblyVersion>1.0.0.59</AssemblyVersion>
     <Authors>Maricopa County Library District Web developers</Authors>
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.58</FileVersion>
+    <FileVersion>1.0.0.59</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Utility/Keys/Cache.cs
+++ b/src/Utility/Keys/Cache.cs
@@ -41,6 +41,16 @@
         public static readonly string OpsJobStop = "jobstop.{0}";
 
         /// <summary>
+        /// Cached email setup element, {0} is the id of the element, {1} is the language id
+        /// </summary>
+        public static readonly string OpsEmailSetup = "emailsetup.{0}.{1}";
+
+        /// <summary>
+        /// Cached email template element, {0} is the id of the element, {1} is the language id
+        /// </summary>
+        public static readonly string OpsEmailTemplate = "emailtemplate.{0}.{1}";
+
+        /// <summary>
         /// Default language ID
         /// </summary>
         public static readonly string PromDefaultLanguageId = "langid-default";

--- a/src/Utility/Services/OcudaBaseService.cs
+++ b/src/Utility/Services/OcudaBaseService.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace Ocuda.Utility.Services
+{
+    public abstract class OcudaBaseService<TService>
+    {
+        protected readonly ILogger<TService> _logger;
+
+        protected OcudaBaseService(ILogger<TService> logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        protected async Task<T> GetFromCacheAsync<T>(IDistributedCache cache, string cacheKey)
+            where T : class
+        {
+            if (cache == null || string.IsNullOrEmpty(cacheKey))
+            {
+                return null;
+            }
+
+            string cachedJson = await cache.GetStringAsync(cacheKey);
+
+            if (!string.IsNullOrEmpty(cachedJson))
+            {
+                _logger.LogTrace("Cache hit for {CacheKey}", cacheKey);
+
+                try
+                {
+                    return JsonSerializer.Deserialize<T>(cachedJson);
+                }
+                catch (JsonException ex)
+                {
+                    _logger.LogWarning(ex,
+                        "Error deserializing {Type} with key {CacheKey} from cache: {ErrorMessage}",
+                        typeof(T),
+                        cacheKey,
+                        ex.Message);
+                    await cache.RemoveAsync(cacheKey);
+                }
+            }
+            return null;
+        }
+
+        protected async Task SaveToCacheAsync<T>(IDistributedCache cache,
+            string cacheKey,
+            T item,
+            int? cacheDurationHours) where T : class
+        {
+            if (cacheDurationHours == null || string.IsNullOrEmpty(cacheKey) || item == null)
+            {
+                return;
+            }
+
+            string itemJson = JsonSerializer.Serialize(item);
+
+            await cache.SetStringAsync(cacheKey,
+                itemJson,
+                new DistributedCacheEntryOptions
+                {
+                    AbsoluteExpirationRelativeToNow = TimeSpan.FromHours((int)cacheDurationHours)
+                });
+
+            _logger.LogDebug("Cache miss for {CacheKey}, caching {Type}: {Length} characters",
+                cacheKey,
+                typeof(T),
+                itemJson.Length);
+        }
+    }
+}


### PR DESCRIPTION
- Refactor base service to support caching in both Ops and Promenade
- Add session storage of which index view is shown for scheduled calls
- Change schedule call actions to go back to previous index view
- Add caching for email setups and templates