### PR TITLE
Fix transitive libraries; suppress EF warnings

### DIFF
--- a/src/Ops.DataProvider.SqlServer.Ops/GlobalSuppressions.cs
+++ b/src/Ops.DataProvider.SqlServer.Ops/GlobalSuppressions.cs
@@ -1,0 +1,27 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Design",
+    "CA1062:Validate arguments of public methods",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Ops.Migrations")]
+[assembly: SuppressMessage("Design",
+    "CA1505:Avoid unmaintainable code",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Ops.Migrations")]
+[assembly: SuppressMessage("Naming",
+    "CA1707:Identifiers should not contain underscores",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Ops.Migrations")]
+[assembly: SuppressMessage("Style",
+    "IDE1006:Naming Styles",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Ops.Migrations")]

--- a/src/Ops.DataProvider.SqlServer.Promenade/GlobalSuppressions.cs
+++ b/src/Ops.DataProvider.SqlServer.Promenade/GlobalSuppressions.cs
@@ -1,0 +1,27 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Design",
+    "CA1062:Validate arguments of public methods",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations")]
+[assembly: SuppressMessage("Design",
+    "CA1505:Avoid unmaintainable code",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations")]
+[assembly: SuppressMessage("Naming",
+    "CA1707:Identifiers should not contain underscores",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations")]
+[assembly: SuppressMessage("Style",
+    "IDE1006:Naming Styles",
+    Justification = "Generated EF Code",
+    Scope = "namespaceanddescendants",
+    Target = "~N:Ocuda.Ops.DataProvider.SqlServer.Promenade.Migrations")]

--- a/src/Ops.Service/Ops.Service.csproj
+++ b/src/Ops.Service/Ops.Service.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="NLayer" Version="1.13.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -28,6 +28,8 @@
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="5.0.0" />
     <PackageReference Include="Stubble.Core" Version="1.9.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Fix outdated references via transitive libraries
- Suppress code analysis warnings on generated EF migrations