### PR TITLE
Fix nativigation aria-labels to be titles

### DIFF
--- a/dev/accessibility.md
+++ b/dev/accessibility.md
@@ -1,0 +1,9 @@
+# Accessibility
+
+Any additions or enhancements to Promenade should include accessibility features.
+
+- Do not duplicate text - if the text is in the link it does not need to be in an `aria-label`
+- Sometimes the `title` property is used to describe an item (like an icon without a label), if used then the `aria-label` and `title` properties should not be the same
+- If using a `title` property then omit the `aria-label` property
+- Do use an `aria-label` containing the text "(opens in a new window)" if that is the case
+  - Parenthesis sometimes cause screen readers to pause which is appropriate for this

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.126</FileVersion>
+    <FileVersion>1.0.0.127</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.126</FileVersion>
+    <FileVersion>1.0.0.127</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Views/Shared/_Layout.cshtml
+++ b/src/Promenade.Web/Views/Shared/_Layout.cshtml
@@ -102,20 +102,13 @@
                                     {
                                         <li class="nav-item @(item.Navigations.Count() == 0 ? "" : "prom-nav-link")">
                                             @if (string.IsNullOrEmpty(item.NavigationText.Label)
-                                                     && !string.IsNullOrEmpty(item.Icon)
-                                                     && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                                && !string.IsNullOrEmpty(item.Icon)
+                                                && !string.IsNullOrEmpty(item.NavigationText.Title))
                                             {
                                                 <a title="@item.NavigationText.Title"
                                                    href="@(string.IsNullOrEmpty(item.Link) ? "#" : item.Link)"
-                                                   class="nav-link @(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
-                                                    @if (!string.IsNullOrEmpty(item.Icon))
-                                                    {
-                                                        <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
-                                                    }
-                                                    @if (!string.IsNullOrEmpty(item.NavigationText.Label))
-                                                    {
-                                                        <span class="@(item.HideTextWhenExtraSmall ? "hidden-xxs" : "")">@item.NavigationText.Label</span>
-                                                    }
+                                                   class="nav-link">
+                                                    <span class="@item.Icon"></span>
                                                 </a>
                                             }
                                             else
@@ -157,18 +150,14 @@
                                                 @foreach (var subItem in item.Navigations)
                                                 {
                                                     <li>
-                                                        @if (string.IsNullOrEmpty(item.NavigationText.Label)
-                                                                && !string.IsNullOrEmpty(item.Icon)
-                                                                && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                                        @if (string.IsNullOrEmpty(subItem.NavigationText.Label)
+                                                            && !string.IsNullOrEmpty(subItem.Icon)
+                                                            && !string.IsNullOrEmpty(subItem.NavigationText.Title))
                                                         {
                                                             <a href="@subItem.Link"
                                                                class="dropdown-item"
-                                                               title="@item.NavigationText.Title">
-                                                                @if (!string.IsNullOrEmpty(subItem.Icon))
-                                                                {
-                                                                    <span class="@subItem.Icon"></span>
-                                                                }
-                                                                @subItem.NavigationText.Label
+                                                               title="@subItem.NavigationText.Title">
+                                                                <span class="@subItem.Icon"></span>
                                                             </a>
                                                         }
                                                         else
@@ -216,12 +205,14 @@
                                 {
                                     <li role="presentation" class="nav-item prom-nav-link">
                                         @if (string.IsNullOrEmpty(item.NavigationText.Label)
-                                                && !string.IsNullOrEmpty(item.Icon)
-                                                && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                            && !string.IsNullOrEmpty(item.Icon)
+                                            && !string.IsNullOrEmpty(item.NavigationText.Title))
                                         {
                                             <a href="@item.Link"
                                                class="nav-link prom-nav-link"
-                                               title="@item.NavigationText.Title">@item.NavigationText.Label</a>
+                                               title="@item.NavigationText.Title">
+                                                <span class="@item.Icon"></span>
+                                            </a>
                                         }
                                         else
                                         {
@@ -244,18 +235,14 @@
                                             @foreach (var subItem in item.Navigations)
                                             {
                                                 <li>
-                                                    @if (string.IsNullOrEmpty(item.NavigationText.Label)
-                                                            && !string.IsNullOrEmpty(item.Icon)
-                                                            && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                                    @if (string.IsNullOrEmpty(subItem.NavigationText.Label)
+                                                        && !string.IsNullOrEmpty(subItem.Icon)
+                                                        && !string.IsNullOrEmpty(subItem.NavigationText.Title))
                                                     {
                                                         <a href="@subItem.Link"
                                                            class="dropdown-item"
-                                                           title="@item.NavigationText.Title">
-                                                            @if (!string.IsNullOrEmpty(subItem.Icon))
-                                                            {
-                                                                <span class="@subItem.Icon"></span>
-                                                            }
-                                                            @subItem.NavigationText.Label
+                                                           title="@subItem.NavigationText.Title">
+                                                            <span class="@subItem.Icon"></span>
                                                         </a>
                                                     }
                                                     else
@@ -313,14 +300,14 @@
                                             {
                                                 <li>
                                                     @if (string.IsNullOrEmpty(subItem.NavigationText.Label)
-                                                              && !string.IsNullOrEmpty(subItem.Icon)
-                                                              && !string.IsNullOrEmpty(subItem.NavigationText.Title))
+                                                        && !string.IsNullOrEmpty(subItem.Icon)
+                                                        && !string.IsNullOrEmpty(subItem.NavigationText.Title))
                                                     {
                                                         <a href="@subItem.Link"
                                                            @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
                                                            title="@subItem.NavigationText.Title"
                                                            aria-label="@(subItem.TargetNewWindow ? "(opens in a new window)" : "")">
-                                                            @subItem.NavigationText.Label
+                                                            <span class="@subItem.Icon"></span>
                                                         </a>
                                                     }
                                                     else
@@ -412,17 +399,12 @@
                         {
                             <div>
                                 @if (string.IsNullOrEmpty(item.NavigationText.Label)
-                                           && !string.IsNullOrEmpty(item.Icon)
-                                           && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                    && !string.IsNullOrEmpty(item.Icon)
+                                    && !string.IsNullOrEmpty(item.NavigationText.Title))
                                 {
                                     <a href="@item.Link"
-                                       title="@item.NavigationText.Title"
-                                       class="@(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
-                                        @if (!string.IsNullOrEmpty(item.Icon))
-                                        {
-                                            <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
-                                        }
-                                        <span class="prom-footer-link-text">@item.NavigationText.Label</span>
+                                       title="@item.NavigationText.Title">
+                                        <span class="@item.Icon"></span>
                                     </a>
                                 }
                                 else

--- a/src/Promenade.Web/Views/Shared/_Layout.cshtml
+++ b/src/Promenade.Web/Views/Shared/_Layout.cshtml
@@ -102,8 +102,10 @@
                                     if (item.ChangeToLinkWhenExtraSmall || item.Navigations.Count() == 0)
                                     {
                                         <li class="nav-item @(item.Navigations.Count() == 0 ? "" : "prom-nav-link")">
-                                            <a title="@item.NavigationText.Title"
-                                               aria-label="@item.NavigationText.AriaLabel"
+                                            <a title="@(string.IsNullOrEmpty(item.NavigationText.Label)
+                                                        && !string.IsNullOrEmpty(item.Icon)
+                                                        && !string.IsNullOrEmpty(item.NavigationText.Title)
+                                                        ? item.NavigationText.Title : null)"
                                                href="@(string.IsNullOrEmpty(item.Link) ? "#" : item.Link)"
                                                class="nav-link @(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
                                                 @if (!string.IsNullOrEmpty(item.Icon))
@@ -142,7 +144,10 @@
                                                     <li>
                                                         <a href="@subItem.Link"
                                                            class="dropdown-item"
-                                                           aria-label="@subItem.NavigationText.AriaLabel">
+                                                           title="@(string.IsNullOrEmpty(item.NavigationText.Label)
+                                                                    && !string.IsNullOrEmpty(item.Icon)
+                                                                    && !string.IsNullOrEmpty(item.NavigationText.Title)
+                                                                    ? item.NavigationText.Title : null)">
                                                             @if (!string.IsNullOrEmpty(subItem.Icon))
                                                             {
                                                                 <span class="@subItem.Icon"></span>
@@ -182,7 +187,10 @@
                                 if (item.ChangeToLinkWhenExtraSmall || item.Navigations.Count() == 0)
                                 {
                                     <li role="presentation" class="nav-item prom-nav-link">
-                                        <a aria-label="@item.NavigationText.AriaLabel"
+                                        <a title="@(string.IsNullOrEmpty(item.NavigationText.Label)
+                                                    && !string.IsNullOrEmpty(item.Icon)
+                                                    && !string.IsNullOrEmpty(item.NavigationText.Title)
+                                                    ? item.NavigationText.Title : null)"
                                            href="@item.Link"
                                            class="nav-link prom-nav-link"
                                            title="@item.NavigationText.Title">@item.NavigationText.Label</a>
@@ -204,7 +212,10 @@
                                                 <li>
                                                     <a href="@subItem.Link"
                                                        class="dropdown-item"
-                                                       aria-label="@subItem.NavigationText.AriaLabel">
+                                                       title="@(string.IsNullOrEmpty(item.NavigationText.Label)
+                                                                && !string.IsNullOrEmpty(item.Icon)
+                                                                && !string.IsNullOrEmpty(item.NavigationText.Title)
+                                                                ? item.NavigationText.Title : null)">
                                                         @if (!string.IsNullOrEmpty(subItem.Icon))
                                                         {
                                                             <span class="@subItem.Icon"></span>
@@ -256,7 +267,11 @@
                                                 <li>
                                                     <a href="@subItem.Link"
                                                        @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
-                                                       aria-label="@subItem.NavigationText.AriaLabel @(subItem.TargetNewWindow ? " (opens new window)" : "")">
+                                                       title="@(string.IsNullOrEmpty(subItem.NavigationText.Label)
+                                                            && !string.IsNullOrEmpty(subItem.Icon)
+                                                            && !string.IsNullOrEmpty(subItem.NavigationText.Title)
+                                                            ? subItem.NavigationText.Title : null)"
+                                                       aria-label="@(subItem.TargetNewWindow ? subItem.NavigationText.Label + " (opens new window)" : "")">
                                                         @subItem.NavigationText.Label
                                                     </a>
                                                 </li>
@@ -269,7 +284,6 @@
                             {
                                 leftNavigationFeaturetteNumber++;
                                 <a href="@item.Link"
-                                   aria-label="@item.NavigationText.AriaLabel"
                                    class="btn btn-secondary btn-block prom-leftnav-featurette-button prom-leftnav-featurette-button-@leftNavigationFeaturetteNumber">@item.NavigationText.Label</a>
                             }
                         }
@@ -283,7 +297,8 @@
                                     <a href="@Context.Items[Ocuda.Promenade.Controllers.ItemKey.SocialFacebookUrl]"
                                        class="prom-leftnav-social-link"
                                        target="_blank"
-                                       aria-label="Visit our Facebook (opens new window)"><span class="fab fa-facebook"></span></a>
+                                       title="Visit our Facebook"
+                                       aria-label="(opens new window)"><span class="fab fa-facebook"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -293,7 +308,8 @@
                                     <a href="@Context.Items[Ocuda.Promenade.Controllers.ItemKey.SocialInstagramUrl]"
                                        class="prom-leftnav-social-link"
                                        target="_blank"
-                                       aria-label="Visit our Instagram (opens new window)"><span class="fab fa-instagram"></span></a>
+                                       title="Visit our Instagram"
+                                       aria-label="(opens new window)"><span class="fab fa-instagram"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -303,7 +319,8 @@
                                     <a href="@Context.Items[Ocuda.Promenade.Controllers.ItemKey.SocialTwitterUrl]"
                                        class="prom-leftnav-social-link"
                                        target="_blank"
-                                       aria-label="Visit our Twitter (opens new window)"><span class="fab fa-twitter"></span></a>
+                                       title="Visit our Twitter"
+                                       aria-label="(opens new window)"><span class="fab fa-twitter"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -313,7 +330,8 @@
                                     <a href="@Context.Items[Ocuda.Promenade.Controllers.ItemKey.SocialYoutubeUrl]"
                                        class="prom-leftnav-social-link"
                                        target="_blank"
-                                       aria-label="Visit our Youtube (opens new window)"><span class="fab fa-youtube"></span></a>
+                                       title="Visit our Youtube"
+                                       aria-label="(opens new window)"><span class="fab fa-youtube"></span></a>
                                 </li>
                             }
                         </ul>
@@ -337,7 +355,10 @@
                         {
                             <div>
                                 <a href="@item.Link"
-                                   aria-label="@item.NavigationText.AriaLabel"
+                                   title="@(string.IsNullOrEmpty(item.NavigationText.Label)
+                                        && !string.IsNullOrEmpty(item.Icon)
+                                        && !string.IsNullOrEmpty(item.NavigationText.Title) ?
+                                        item.NavigationText.Title : null)"
                                    class="@(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
                                     @if (!string.IsNullOrEmpty(item.Icon))
                                     {

--- a/src/Promenade.Web/Views/Shared/_Layout.cshtml
+++ b/src/Promenade.Web/Views/Shared/_Layout.cshtml
@@ -22,7 +22,6 @@
                 window.dataLayer = window.dataLayer || [];
                 function gtag() { dataLayer.push(arguments); }
                 gtag('js', new Date());
-
                 gtag('config', '@googleAnalyticsTrackingCode');
             </script>
         }
@@ -320,7 +319,7 @@
                                                         <a href="@subItem.Link"
                                                            @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
                                                            title="@subItem.NavigationText.Title"
-                                                           aria-label="@(subItem.TargetNewWindow ? "(opens new window)" : "")">
+                                                           aria-label="@(subItem.TargetNewWindow ? "(opens in a new window)" : "")">
                                                             @subItem.NavigationText.Label
                                                         </a>
                                                     }
@@ -328,7 +327,7 @@
                                                     {
                                                         <a href="@subItem.Link"
                                                            @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
-                                                           aria-label="@(subItem.TargetNewWindow ? subItem.NavigationText.Label + " (opens new window)" : "")">
+                                                           aria-label="@(subItem.TargetNewWindow ? subItem.NavigationText.Label + " (opens in a new window)" : "")">
                                                             @subItem.NavigationText.Label
                                                         </a>
                                                     }
@@ -356,7 +355,7 @@
                                        class="prom-leftnav-social-link"
                                        target="_blank"
                                        title="Visit our Facebook"
-                                       aria-label="(opens new window)"><span class="fab fa-facebook"></span></a>
+                                       aria-label="(opens in a new window)"><span class="fab fa-facebook"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -367,7 +366,7 @@
                                        class="prom-leftnav-social-link"
                                        target="_blank"
                                        title="Visit our Instagram"
-                                       aria-label="(opens new window)"><span class="fab fa-instagram"></span></a>
+                                       aria-label="(opens in a new window)"><span class="fab fa-instagram"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -378,7 +377,7 @@
                                        class="prom-leftnav-social-link"
                                        target="_blank"
                                        title="Visit our Twitter"
-                                       aria-label="(opens new window)"><span class="fab fa-twitter"></span></a>
+                                       aria-label="(opens in a new window)"><span class="fab fa-twitter"></span></a>
                                     <span>&nbsp;</span>
                                 </li>
                             }
@@ -389,7 +388,7 @@
                                        class="prom-leftnav-social-link"
                                        target="_blank"
                                        title="Visit our Youtube"
-                                       aria-label="(opens new window)"><span class="fab fa-youtube"></span></a>
+                                       aria-label="(opens in a new window)"><span class="fab fa-youtube"></span></a>
                                 </li>
                             }
                         </ul>

--- a/src/Promenade.Web/Views/Shared/_Layout.cshtml
+++ b/src/Promenade.Web/Views/Shared/_Layout.cshtml
@@ -102,21 +102,37 @@
                                     if (item.ChangeToLinkWhenExtraSmall || item.Navigations.Count() == 0)
                                     {
                                         <li class="nav-item @(item.Navigations.Count() == 0 ? "" : "prom-nav-link")">
-                                            <a title="@(string.IsNullOrEmpty(item.NavigationText.Label)
-                                                        && !string.IsNullOrEmpty(item.Icon)
-                                                        && !string.IsNullOrEmpty(item.NavigationText.Title)
-                                                        ? item.NavigationText.Title : null)"
-                                               href="@(string.IsNullOrEmpty(item.Link) ? "#" : item.Link)"
-                                               class="nav-link @(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
-                                                @if (!string.IsNullOrEmpty(item.Icon))
-                                                {
-                                                    <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
-                                                }
-                                                @if (!string.IsNullOrEmpty(item.NavigationText.Label))
-                                                {
-                                                    <span class="@(item.HideTextWhenExtraSmall ? "hidden-xxs" : "")">@item.NavigationText.Label</span>
-                                                }
-                                            </a>
+                                            @if (string.IsNullOrEmpty(item.NavigationText.Label)
+                                                     && !string.IsNullOrEmpty(item.Icon)
+                                                     && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                            {
+                                                <a title="@item.NavigationText.Title"
+                                                   href="@(string.IsNullOrEmpty(item.Link) ? "#" : item.Link)"
+                                                   class="nav-link @(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
+                                                    @if (!string.IsNullOrEmpty(item.Icon))
+                                                    {
+                                                        <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(item.NavigationText.Label))
+                                                    {
+                                                        <span class="@(item.HideTextWhenExtraSmall ? "hidden-xxs" : "")">@item.NavigationText.Label</span>
+                                                    }
+                                                </a>
+                                            }
+                                            else
+                                            {
+                                                <a href="@(string.IsNullOrEmpty(item.Link) ? "#" : item.Link)"
+                                                   class="nav-link @(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
+                                                    @if (!string.IsNullOrEmpty(item.Icon))
+                                                    {
+                                                        <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
+                                                    }
+                                                    @if (!string.IsNullOrEmpty(item.NavigationText.Label))
+                                                    {
+                                                        <span class="@(item.HideTextWhenExtraSmall ? "hidden-xxs" : "")">@item.NavigationText.Label</span>
+                                                    }
+                                                </a>
+                                            }
                                         </li>
                                     }
                                     if (item.Navigations.Count() > 0)
@@ -142,18 +158,31 @@
                                                 @foreach (var subItem in item.Navigations)
                                                 {
                                                     <li>
-                                                        <a href="@subItem.Link"
-                                                           class="dropdown-item"
-                                                           title="@(string.IsNullOrEmpty(item.NavigationText.Label)
-                                                                    && !string.IsNullOrEmpty(item.Icon)
-                                                                    && !string.IsNullOrEmpty(item.NavigationText.Title)
-                                                                    ? item.NavigationText.Title : null)">
-                                                            @if (!string.IsNullOrEmpty(subItem.Icon))
-                                                            {
-                                                                <span class="@subItem.Icon"></span>
-                                                            }
-                                                            @subItem.NavigationText.Label
-                                                        </a>
+                                                        @if (string.IsNullOrEmpty(item.NavigationText.Label)
+                                                                && !string.IsNullOrEmpty(item.Icon)
+                                                                && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                                        {
+                                                            <a href="@subItem.Link"
+                                                               class="dropdown-item"
+                                                               title="@item.NavigationText.Title">
+                                                                @if (!string.IsNullOrEmpty(subItem.Icon))
+                                                                {
+                                                                    <span class="@subItem.Icon"></span>
+                                                                }
+                                                                @subItem.NavigationText.Label
+                                                            </a>
+                                                        }
+                                                        else
+                                                        {
+                                                            <a href="@subItem.Link"
+                                                               class="dropdown-item">
+                                                                @if (!string.IsNullOrEmpty(subItem.Icon))
+                                                                {
+                                                                    <span class="@subItem.Icon"></span>
+                                                                }
+                                                                @subItem.NavigationText.Label
+                                                            </a>
+                                                        }
                                                     </li>
                                                 }
                                             </ul>
@@ -187,13 +216,19 @@
                                 if (item.ChangeToLinkWhenExtraSmall || item.Navigations.Count() == 0)
                                 {
                                     <li role="presentation" class="nav-item prom-nav-link">
-                                        <a title="@(string.IsNullOrEmpty(item.NavigationText.Label)
-                                                    && !string.IsNullOrEmpty(item.Icon)
-                                                    && !string.IsNullOrEmpty(item.NavigationText.Title)
-                                                    ? item.NavigationText.Title : null)"
-                                           href="@item.Link"
-                                           class="nav-link prom-nav-link"
-                                           title="@item.NavigationText.Title">@item.NavigationText.Label</a>
+                                        @if (string.IsNullOrEmpty(item.NavigationText.Label)
+                                                && !string.IsNullOrEmpty(item.Icon)
+                                                && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                        {
+                                            <a href="@item.Link"
+                                               class="nav-link prom-nav-link"
+                                               title="@item.NavigationText.Title">@item.NavigationText.Label</a>
+                                        }
+                                        else
+                                        {
+                                            <a href="@item.Link"
+                                               class="nav-link prom-nav-link">@item.NavigationText.Label</a>
+                                        }
                                     </li>
                                 }
                                 if (item.Navigations.Count() > 0)
@@ -210,18 +245,31 @@
                                             @foreach (var subItem in item.Navigations)
                                             {
                                                 <li>
-                                                    <a href="@subItem.Link"
-                                                       class="dropdown-item"
-                                                       title="@(string.IsNullOrEmpty(item.NavigationText.Label)
-                                                                && !string.IsNullOrEmpty(item.Icon)
-                                                                && !string.IsNullOrEmpty(item.NavigationText.Title)
-                                                                ? item.NavigationText.Title : null)">
-                                                        @if (!string.IsNullOrEmpty(subItem.Icon))
-                                                        {
-                                                            <span class="@subItem.Icon"></span>
-                                                        }
-                                                        @subItem.NavigationText.Label
-                                                    </a>
+                                                    @if (string.IsNullOrEmpty(item.NavigationText.Label)
+                                                            && !string.IsNullOrEmpty(item.Icon)
+                                                            && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                                    {
+                                                        <a href="@subItem.Link"
+                                                           class="dropdown-item"
+                                                           title="@item.NavigationText.Title">
+                                                            @if (!string.IsNullOrEmpty(subItem.Icon))
+                                                            {
+                                                                <span class="@subItem.Icon"></span>
+                                                            }
+                                                            @subItem.NavigationText.Label
+                                                        </a>
+                                                    }
+                                                    else
+                                                    {
+                                                        <a href="@subItem.Link"
+                                                           class="dropdown-item">
+                                                            @if (!string.IsNullOrEmpty(subItem.Icon))
+                                                            {
+                                                                <span class="@subItem.Icon"></span>
+                                                            }
+                                                            @subItem.NavigationText.Label
+                                                        </a>
+                                                    }
                                                 </li>
                                             }
                                         </ul>
@@ -265,15 +313,25 @@
                                             @foreach (var subItem in item.Navigations)
                                             {
                                                 <li>
-                                                    <a href="@subItem.Link"
-                                                       @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
-                                                       title="@(string.IsNullOrEmpty(subItem.NavigationText.Label)
-                                                            && !string.IsNullOrEmpty(subItem.Icon)
-                                                            && !string.IsNullOrEmpty(subItem.NavigationText.Title)
-                                                            ? subItem.NavigationText.Title : null)"
-                                                       aria-label="@(subItem.TargetNewWindow ? subItem.NavigationText.Label + " (opens new window)" : "")">
-                                                        @subItem.NavigationText.Label
-                                                    </a>
+                                                    @if (string.IsNullOrEmpty(subItem.NavigationText.Label)
+                                                              && !string.IsNullOrEmpty(subItem.Icon)
+                                                              && !string.IsNullOrEmpty(subItem.NavigationText.Title))
+                                                    {
+                                                        <a href="@subItem.Link"
+                                                           @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
+                                                           title="@subItem.NavigationText.Title"
+                                                           aria-label="@(subItem.TargetNewWindow ? "(opens new window)" : "")">
+                                                            @subItem.NavigationText.Label
+                                                        </a>
+                                                    }
+                                                    else
+                                                    {
+                                                        <a href="@subItem.Link"
+                                                           @(subItem.TargetNewWindow ? "target=\"_blank\"" : "")
+                                                           aria-label="@(subItem.TargetNewWindow ? subItem.NavigationText.Label + " (opens new window)" : "")">
+                                                            @subItem.NavigationText.Label
+                                                        </a>
+                                                    }
                                                 </li>
                                             }
                                         </ul>
@@ -354,18 +412,31 @@
                         @foreach (var item in footerNavigation.Navigations)
                         {
                             <div>
-                                <a href="@item.Link"
-                                   title="@(string.IsNullOrEmpty(item.NavigationText.Label)
-                                        && !string.IsNullOrEmpty(item.Icon)
-                                        && !string.IsNullOrEmpty(item.NavigationText.Title) ?
-                                        item.NavigationText.Title : null)"
-                                   class="@(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
-                                    @if (!string.IsNullOrEmpty(item.Icon))
-                                    {
-                                        <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
-                                    }
-                                    <span class="prom-footer-link-text">@item.NavigationText.Label</span>
-                                </a>
+                                @if (string.IsNullOrEmpty(item.NavigationText.Label)
+                                           && !string.IsNullOrEmpty(item.Icon)
+                                           && !string.IsNullOrEmpty(item.NavigationText.Title))
+                                {
+                                    <a href="@item.Link"
+                                       title="@item.NavigationText.Title"
+                                       class="@(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
+                                        @if (!string.IsNullOrEmpty(item.Icon))
+                                        {
+                                            <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
+                                        }
+                                        <span class="prom-footer-link-text">@item.NavigationText.Label</span>
+                                    </a>
+                                }
+                                else
+                                {
+                                    <a href="@item.Link"
+                                       class="@(item.NavigationText.Label == null ? "" : "d-flex align-items-center")">
+                                        @if (!string.IsNullOrEmpty(item.Icon))
+                                        {
+                                            <span class="@item.Icon @(item.NavigationText.Label == null ? "" : "prom-fa-space")"></span>
+                                        }
+                                        <span class="prom-footer-link-text">@item.NavigationText.Label</span>
+                                    </a>
+                                }
                             </div>
                         }
                     </div>


### PR DESCRIPTION
Adds `aria-label` if link opens new window.

- Adds `NavigationText.Label` to aria-label if `title` is not present

Adds `title` if there isnt a `NavigationText.Label` but, exists a `Navigation.Icon` and `NavigationText.Title`