### PR TITLE
Add Google Analytics for podcast plays

### DIFF
--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.158</FileVersion>
+    <FileVersion>1.0.0.159</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.158</FileVersion>
+    <FileVersion>1.0.0.159</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -17,9 +17,10 @@
     </div>
 </div>
 
-@if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
-{
-    <script>
+@section scripts {
+    @if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
+    {
+        <script>
         var player = document.getElementById("player");
         player.addEventListener("play", function () {
             gtag('event', 'Podcast play', {
@@ -27,5 +28,6 @@
                 'event_label': '@Model.PodcastItem.Episode.Value'
             });
         });
-    </script>
-} 
+        </script>
+    }
+}

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -23,9 +23,9 @@
         var player = document.getElementById("player");
         player.addEventListener("play", function () {
             gtag('event', 'Podcast play', {
-                'event_category': '@Model.Podcast.Title',
+                'event_category': '@Html.Raw(Model.Podcast.Title.Replace("'", "\\'"))',
                 'event_label': '@Model.PodcastItem.Episode.Value'
             });
         });
     </script>
- } 
+} 

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -9,10 +9,23 @@
                 @Localizer[Promenade.PodcastEpisodePublished, Model.PodcastItem.Episode, Model.PodcastItem.PublishDate.Value.ToLongDateString()]
             </em>
         </div>
-        <audio controls class="mb-2 w-100">
+        <audio id="player" controls class="mb-2 w-100">
             <source src="@Model.PodcastItem.MediaUrl" type="@Model.PodcastItem.MediaType" />
         </audio>
         <p>@Model.PodcastItem.Description</p>
         <div><em>@Localizer[Promenade.KeywordsItem, Model.PodcastItem.Keywords]</em></div>
     </div>
 </div>
+
+@if (!string.IsNullOrWhiteSpace(Context.Items[Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode] as string))
+{
+    <script>
+        var player = document.getElementById("player");
+        player.addEventListener("play", function () {
+            gtag('event', 'Podcast play', {
+                'event_category': '@Model.Podcast.Title',
+                'event_label': '@Model.PodcastItem.Episode.Value'
+            });
+        });
+    </script>
+ } 

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -17,7 +17,7 @@
     </div>
 </div>
 
-@if (!string.IsNullOrWhiteSpace(Context.Items[Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode] as string))
+@if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
 {
     <script>
         var player = document.getElementById("player");

--- a/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
@@ -69,9 +69,10 @@
         </div>
     </div>
 }
-@if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
-{
-    <script>
+@section scripts {
+    @if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
+    {
+        <script>
         var players = document.getElementsByTagName("audio");
         for (var index = 0; index < players.length; index++) {
             var episode = players[index].getAttribute("data-episode");
@@ -82,5 +83,6 @@
                 });
             });
         }
-    </script>
+        </script>
+    }
 }

--- a/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
@@ -77,7 +77,7 @@
             var episode = players[index].getAttribute("data-episode");
             players[index].addEventListener("play", function () {
                 gtag('event', 'Podcast play', {
-                    'event_category': '@Model.Podcast.Title',
+                    'event_category': '@Html.Raw(Model.Podcast.Title.Replace("'", "\\'"))',
                     'event_label': episode
                 });
             });

--- a/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
@@ -69,7 +69,7 @@
         </div>
     </div>
 }
-@if (!string.IsNullOrWhiteSpace(Context.Items[Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode] as string))
+@if (Context.Items.ContainsKey(Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode))
 {
     <script>
         var players = document.getElementsByTagName("audio");

--- a/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
@@ -48,7 +48,7 @@
                     <div class="mb-2"><em>@Localizer[Promenade.PodcastEpisodePublished, item.Episode, item.PublishDate.Value.ToLongDateString()]</em></div>
                 </div>
                 <div class="col-12 col-lg-6 col-xl-5 text-right">
-                    <audio controls class="mb-2 w-100">
+                    <audio controls class="mb-2 w-100" data-episode="@item.Episode.Value">
                         <source src="@item.MediaUrl" type="@item.MediaType" />
                     </audio>
                 </div>
@@ -68,4 +68,19 @@
             <paginate paginateModel="@Model.PaginateModel"></paginate>
         </div>
     </div>
+}
+@if (!string.IsNullOrWhiteSpace(Context.Items[Ocuda.Promenade.Controllers.ItemKey.GoogleAnalyticsTrackingCode] as string))
+{
+    <script>
+        var players = document.getElementsByTagName("audio");
+        for (var index = 0; index < players.length; index++) {
+            var episode = players[index].getAttribute("data-episode");
+            players[index].addEventListener("play", function () {
+                gtag('event', 'Podcast play', {
+                    'event_category': '@Model.Podcast.Title',
+                    'event_label': episode
+                });
+            });
+        }
+    </script>
 }


### PR DESCRIPTION
Fix #380 Add Google Analytics event when user plays a podcast
For easy Google Analytics testing, in the left sidebar, go to Reports> Realtime> Events.  The data sending will then appear in realtime.