### PR TITLE
Add Podcast show notes to Promenade

### DIFF
--- a/src/Ops.Web/Areas/SiteManagement/Views/Segments/Detail.cshtml
+++ b/src/Ops.Web/Areas/SiteManagement/Views/Segments/Detail.cshtml
@@ -1,7 +1,7 @@
 ﻿@model Ocuda.Ops.Controllers.Areas.SiteManagement.ViewModels.Segment.DetailViewModel
 
 @section styles {
-    <link rel="stylesheet" href="~/css/md.min.css" asp-append-version="true" />
+<link rel="stylesheet" href="~/css/md.min.css" asp-append-version="true" />
 }
 
 <div class="row mb-2">
@@ -15,22 +15,22 @@
         @if (!string.IsNullOrEmpty(Model.BackLink))
         {
             <a href="@Model.BackLink"
-               class="btn btn-outline-dark mt-2 mb-1 ml-2 float-right">Back</a>
+           class="btn btn-outline-dark mt-2 mb-1 ml-2 float-right">Back</a>
         }
         else
         {
             <a asp-action="Index"
-               class="btn btn-outline-dark mt-2 mb-1 ml-2 float-right">Cancel</a>
+           class="btn btn-outline-dark mt-2 mb-1 ml-2 float-right">Cancel</a>
         }
         @if (!Model.NewSegmentText && string.IsNullOrEmpty(Model.BackLink))
         {
             <button type="button"
-                    class="btn btn-outline-danger mt-2 mb-1 mr-2 float-right"
-                    data-toggle="modal"
-                    data-target="#deleteModal"
-                    data-segmentId="@Model.SegmentId"
-                    data-languageId="@Model.LanguageId"
-                    data-languageDescription="@Model.LanguageDescription">
+                class="btn btn-outline-danger mt-2 mb-1 mr-2 float-right"
+                data-toggle="modal"
+                data-target="#deleteModal"
+                data-segmentId="@Model.SegmentId"
+                data-languageId="@Model.LanguageId"
+                data-languageDescription="@Model.LanguageDescription">
                 <span class="fas fa-minus-circle"></span>
                 Delete Segment
             </button>
@@ -64,24 +64,42 @@
     </div>
 }
 
-<div class="row" style="padding-top: 1rem;">
+<div class="row py-2">
     <div class="col-12">
         <span class="d-none"><input asp-for="SegmentName" formgroup readonly /></span>
-        <input asp-for="SegmentStartDate"
+        @if (Model.SegmentStartDate.HasValue || Model.SegmentEndDate.HasValue)
+        {
+            <input asp-for="SegmentStartDate"
                formgroup
                value="@Model.SegmentStartDate?.ToString()"
                readonly />
-        <input asp-for="SegmentEndDate"
+            <input asp-for="SegmentEndDate"
                formgroup
                value="@Model.SegmentStartDate?.ToString()"
                readonly />
-        <select asp-for="SelectedLanguage" asp-items="Model.LanguageList" formgroup></select>
-    </div>
-</div>
-
-<div class="row" style="padding-bottom: 1rem;">
-    <div class="col-12 col-md-9 offset-md-3">
-        <hr />
+        }
+        @if (Model.LanguageList?.Count() > 1)
+        {
+            <div class="form-group row">
+                <div class="col-md-3 text-md-right">
+                    <label asp-for="SelectedLanguage" class="col-form-label"></label>
+                </div>
+                <div class="col-md-9">
+                    @foreach (var item in Model.LanguageList.Where(_ => !_.Disabled))
+                    {
+                        <a href="@Url.Action(nameof(SegmentsController.Detail), new { id = Model.SegmentId, language = item.Value })"
+                   class="btn btn-sm btn-outline-info mt-1 @(item.Selected ? "active" : null)">@item.Text</a>
+                    }
+                </div>
+            </div>
+            <div class="row d-none oc-save-warning">
+                <div class="offset-md-3 col-md-9">
+                    <div class="alert alert-warning">
+                        <span class="fas fa-arrow-circle-up"></span> Unsaved changes will be lost if you change languages.
+                    </div>
+                </div>
+            </div>
+        }
     </div>
 </div>
 
@@ -104,37 +122,46 @@
 
     <div class="row">
         <div class="offset-md-3 col-md-9">
-            <button type="submit"
-                    class="btn btn-outline-success btn-lg"
-                    buttonspinner>
-                <span class="far fa-save"></span>
-                Save
-            </button>
+            <div class="d-flex">
+                <button type="submit"
+                        class="btn btn-outline-success btn-lg"
+                        buttonspinner>
+                    <span class="far fa-save"></span>
+                    Save
+                </button>
+                <div class="d-none oc-save-warning ml-3 flex-fill">
+                    <div class="alert alert-warning mb-0">
+                        <span class="fas fa-exclamation-triangle"></span>
+                        You have unsaved changes.
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </form>
 
 @section scripts {
-    <script src="~/js/md.min.js" asp-append-version="true"></script>
+<script src="~/js/md.min.js" asp-append-version="true"></script>
 
-    <script>
-        $(function () {
-            var editor = new Markdown.Editor($("#SegmentText_Text"), { allowUploads: false });
-            if (editor) {
-                editor.run();
-            }
-        });
+<script>
+    $(function () {
+        var editor = new Markdown.Editor($("#SegmentText_Text"), { allowUploads: false, allowImages: false });
+        if (editor) {
+            editor.run();
+        }
+    });
 
-        var segmentDetailsUrl
-            = "@Url.Action(nameof(SegmentsController.Detail), new { id = Model.SegmentId })";
+    $("#SegmentText_Text").keydown(function(event) {
+        $(".oc-save-warning").removeClass("d-none");
+    });
 
-        $("#SelectedLanguage").on("change", function () {
-            window.location.href = segmentDetailsUrl + "?language=" + $(this).val();
-        });
+    $("#SegmentText_Header").keydown(function(event) {
+        $(".oc-save-warning").removeClass("d-none");
+    });
 
-        $("#deleteModal").on("show.bs.modal", function (e) {
-            var languageDescription = $(e.relatedTarget).data("languagedescription");
-            $(this).find(".modal-text").text("Are you sure you want to delete the " + languageDescription + " text for this segment?");
-        });
-    </script>
+    $("#deleteModal").on("show.bs.modal", function (e) {
+        var languageDescription = $(e.relatedTarget).data("languagedescription");
+        $(this).find(".modal-text").text("Are you sure you want to delete the " + languageDescription + " text for this segment?");
+    });
+</script>
 }

--- a/src/Promenade.Controllers/PodcastsController.cs
+++ b/src/Promenade.Controllers/PodcastsController.cs
@@ -25,16 +25,20 @@ namespace Ocuda.Promenade.Controllers
     {
         private readonly IPathResolverService _pathResolverService;
         private readonly PodcastService _podcastService;
+        private readonly SegmentService _segmentService;
 
         public PodcastsController(ServiceFacades.Controller<PodcastsController> context,
             IPathResolverService pathResolverService,
-            PodcastService podcastService)
+            PodcastService podcastService,
+            SegmentService segmentService)
             : base(context)
         {
             _pathResolverService = pathResolverService
                 ?? throw new ArgumentNullException(nameof(pathResolverService));
             _podcastService = podcastService
                 ?? throw new ArgumentNullException(nameof(podcastService));
+            _segmentService = segmentService
+                ?? throw new ArgumentNullException(nameof(segmentService));
         }
 
         public static string Name { get { return "Podcasts"; } }
@@ -483,6 +487,49 @@ namespace Ocuda.Promenade.Controllers
                     .ToString("R", CultureInfo.InvariantCulture));
 
             return File(stream.ToArray(), "application/rss+xml; charset=utf-8");
+        }
+
+        [Route("{podcastStub}/{episodeStub}/[action]")]
+        public async Task<IActionResult> ShowNotes(string podcastStub, string episodeStub)
+        {
+            var podcast = await _podcastService.GetByStubAsync(podcastStub?.Trim());
+
+            if (podcast == null)
+            {
+                return RedirectToAction(nameof(Index));
+            }
+
+            var podcastItem = await _podcastService
+                .GetItemByStubAsync(podcast.Id, episodeStub?.Trim());
+
+            if (podcastItem == null)
+            {
+                return RedirectToAction(nameof(Podcast), new { stub = podcastStub });
+            }
+
+            if (podcastItem.ShowNotesSegmentId.HasValue)
+            {
+                var segmentText = await _segmentService.GetSegmentTextBySegmentIdAsync(
+                    podcastItem.ShowNotesSegmentId.Value, false);
+
+                segmentText.Text = CommonMark.CommonMarkConverter.Convert(
+                        segmentText.Text);
+
+                var viewModel = new ShowNotesViewModel
+                {
+                    Podcast = podcast,
+                    PodcastItem = podcastItem,
+                    ShowNotesSegment = segmentText
+                };
+
+                PageTitle = $"{_localizer[i18n.Keys.Promenade.ShowNotesFor, podcastItem.Title]} - {podcast.Title}";
+
+                return View(viewModel);
+            }
+            else
+            {
+                return NotFound();
+            }
         }
     }
 }

--- a/src/Promenade.Controllers/ViewModels/Podcasts/ShowNotesViewModel.cs
+++ b/src/Promenade.Controllers/ViewModels/Podcasts/ShowNotesViewModel.cs
@@ -1,0 +1,11 @@
+﻿using Ocuda.Promenade.Models.Entities;
+
+namespace Ocuda.Promenade.Controllers.ViewModels.Podcasts
+{
+    public class ShowNotesViewModel
+    {
+        public Podcast Podcast { get; set; }
+        public PodcastItem PodcastItem { get; set; }
+        public SegmentText ShowNotesSegment { get; set; }
+    }
+}

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -2,12 +2,29 @@
 
 <div class="row">
     <div class="col-12">
-        <h1 class="mb-2">@Model.PodcastItem.Title</h1>
-        <div class="mb-4">
-            <em>
-                <a href="@Url.Action(nameof(PodcastsController.Podcast), new { stub = Model.Podcast.Stub})">@Localizer[Promenade.PodcastTitle, Model.Podcast.Title]</a>.
-                @Localizer[Promenade.PodcastEpisodePublished, Model.PodcastItem.Episode, Model.PodcastItem.PublishDate.Value.ToLongDateString()]
-            </em>
+        <div class="row">
+            <div class="col-12 col-lg-6 col-xl-7">
+                <h1 class="mb-2">@Model.PodcastItem.Title</h1>
+                <div class="mb-2">
+                    <em>
+                        <a href="@Url.Action(nameof(PodcastsController.Podcast), new { stub = Model.Podcast.Stub})">@Localizer[Promenade.PodcastTitle, Model.Podcast.Title]</a>.
+                        @Localizer[Promenade.PodcastEpisodePublished, Model.PodcastItem.Episode, Model.PodcastItem.PublishDate.Value.ToLongDateString()]
+                    </em>
+                </div>
+            </div>
+            <div class="col-12 col-lg-6 col-xl-5 text-sm-left text-md-left text-lg-right">
+                @if (Model.PodcastItem.ShowNotesSegmentId.HasValue)
+                {
+                    <div class="mb-4 mb-sm-2">
+                        <a href="@Url.Action(nameof(PodcastsController.ShowNotes), new { podcastStub = Model.Podcast.Stub, episodeStub = Model.PodcastItem.Stub})"
+                           target="_blank"
+                           class="btn d-block d-md-inline-block btn-outline-primary">
+                            @Localizer[Promenade.ViewShowNotes]
+                            <span class="sr-only">@Localizer[Promenade.NewWindow]</span>
+                        </a>
+                    </div>
+                }
+            </div>
         </div>
         <audio controls class="mb-2 w-100">
             <source src="@Model.PodcastItem.MediaUrl" type="@Model.PodcastItem.MediaType" />

--- a/src/Promenade.Web/Views/Podcasts/Episode.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Episode.cshtml
@@ -3,7 +3,7 @@
 <div class="row">
     <div class="col-12">
         <div class="row">
-            <div class="col-12 col-lg-6 col-xl-7">
+            <div class="col-12 col-lg">
                 <h1 class="mb-2">@Model.PodcastItem.Title</h1>
                 <div class="mb-2">
                     <em>
@@ -12,7 +12,7 @@
                     </em>
                 </div>
             </div>
-            <div class="col-12 col-lg-6 col-xl-5 text-sm-left text-md-left text-lg-right">
+            <div class="col-12 col-lg-auto text-sm-left text-md-left text-lg-right">
                 @if (Model.PodcastItem.ShowNotesSegmentId.HasValue)
                 {
                     <div class="mb-4 mb-sm-2">

--- a/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/Podcast.cshtml
@@ -45,7 +45,9 @@
                             @item.Title
                         </a>
                     </h2>
-                    <div class="mb-2"><em>@Localizer[Promenade.PodcastEpisodePublished, item.Episode, item.PublishDate.Value.ToLongDateString()]</em></div>
+                    <div class="mb-2">
+                        <em>@Localizer[Promenade.PodcastEpisodePublished, item.Episode, item.PublishDate.Value.ToLongDateString()]</em>
+                    </div>
                 </div>
                 <div class="col-12 col-lg-6 col-xl-5 text-right">
                     <audio controls class="mb-2 w-100">
@@ -56,6 +58,16 @@
         </div>
         <div class="col-12">
             <p>@item.Description</p>
+            @if (item.ShowNotesSegmentId.HasValue)
+            {
+                <a href="@Url.Action(nameof(PodcastsController.ShowNotes), new { podcastStub = Model.Podcast.Stub, episodeStub = item.Stub})"
+                   target="_blank"
+                   aria-label="@Localizer[Promenade.NewWindow]"
+                   title="@Localizer[Promenade.ShowNotesFor, item.Title]"
+                   class="btn d-block d-md-inline-block btn-outline-primary">
+                    @Localizer[Promenade.ViewShowNotes]
+                </a>
+            }
         </div>
     </div>
     <hr aria-hidden="true" />

--- a/src/Promenade.Web/Views/Podcasts/ShowNotes.cshtml
+++ b/src/Promenade.Web/Views/Podcasts/ShowNotes.cshtml
@@ -1,0 +1,15 @@
+﻿@model Ocuda.Promenade.Controllers.ViewModels.Podcasts.ShowNotesViewModel
+
+<div class="row">
+    <div class="col-12">
+            <h1 class="mb-2">@Localizer[Promenade.ShowNotesFor, Model.PodcastItem.Title]</h1>
+        <div class="mb-4">
+            <em>
+                <a href="@Url.Action(nameof(PodcastsController.Podcast), new { stub = Model.Podcast.Stub })">@Localizer[Promenade.PodcastTitle, Model.Podcast.Title]</a>.
+                @Localizer[Promenade.PodcastEpisodePublished, Model.PodcastItem.Episode, Model.PodcastItem.PublishDate.Value.ToLongDateString()]
+            </em>
+        </div>
+        <div>@Html.Raw(Model.ShowNotesSegment.Text)</div>
+        <div><em>@Localizer[Promenade.KeywordsItem, Model.PodcastItem.Keywords]</em></div>
+    </div>
+</div>

--- a/src/i18n/Keys/Promenade.cs
+++ b/src/i18n/Keys/Promenade.cs
@@ -80,6 +80,8 @@
         public static readonly string ScheduleRequiredNotes = "Please help us out by telling us a little about your request.";
         public static readonly string ScheduleYourTime = "Schedule your time";
         public static readonly string ScheduleYourTimeIsScheduled = "Your time is scheduled";
+        public static readonly string ShowNotesFor = "Show Notes for {0}";
+        public static readonly string ViewShowNotes = "View show notes";
         public static readonly string VisitHomePage = "Visit home page";
         public static readonly string ZipCodeClosest = "Libraries closest to ZIP code: {0}";
         public static readonly string ZipCodePrompt = "Enter a 5 digit ZIP code";

--- a/src/i18n/Resources/Shared.en.resx
+++ b/src/i18n/Resources/Shared.en.resx
@@ -689,4 +689,12 @@
     <value>Enter a 5 digit ZIP code</value>
     <comment>Prompt to enter a five digit ZIP code to find the nearest locations</comment>
   </data>
+  <data name="Show Notes for {0}">
+    <value>Show Notes for {0}</value>
+    <comment>Header for a podcast's show notes; {0} is the episode title</comment>
+  </data>
+  <data name="View show notes">
+    <value>View show notes</value>
+    <comment>Label that links to a podcast's show notes</comment>
+  </data>
 </root>

--- a/src/i18n/Resources/Shared.es.resx
+++ b/src/i18n/Resources/Shared.es.resx
@@ -689,4 +689,12 @@
     <value>Ingrese un código postal de 5 dígitos</value>
     <comment>Prompt to enter a five digit ZIP code to find the nearest locations</comment>
   </data>
+  <data name="Show Notes for {0}">
+    <value>{0}</value>
+    <comment>Header for a podcast's show notes; {0} is the episode title</comment>
+  </data>
+  <data name="View show notes">
+    <value></value>
+    <comment>Label that links to a podcast's show notes</comment>
+  </data>
 </root>


### PR DESCRIPTION
Fix #394 Add Podcast show notes to Promenade
- Shownotes are accessible at `/podcasts/podcast.stub/podcastItem.stub/shownotes/`
- You can view podcasts that have linked SegmentText's on the show notes page
- Podcasts that dont have linked SegmentText's are redirected to `NotFound();`