### PR TITLE
Upgrade packages; modify health check; guideline

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 # Don't use tabs for indentation.
 [*]
 indent_style = space
+guidelines = 100
 # (Please don't specify an indent_size here; that has too many unintended consequences.)
 
 # Code files

--- a/src/Ops.Data/Ops.Data.csproj
+++ b/src/Ops.Data/Ops.Data.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
   </ItemGroup>
 
 </Project>

--- a/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
+++ b/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ops.Service/Ops.Service.csproj
+++ b/src/Ops.Service/Ops.Service.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="ExcelDataReader" Version="3.6.0" />
-    <PackageReference Include="MailKit" Version="2.15.0" />
+    <PackageReference Include="MailKit" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="NLayer" Version="1.14.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -38,15 +38,14 @@
 
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.12">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.13">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.12" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" PrivateAssets="All" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.159</FileVersion>
+    <FileVersion>1.0.0.160</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Ops.Web/Startup.cs
+++ b/src/Ops.Web/Startup.cs
@@ -194,9 +194,7 @@ namespace Ocuda.Ops.Web
                         DataProvider.SqlServer.Ops.Context>(_ => _.UseSqlServer(opsCs));
                     services.AddDbContextPool<PromenadeContext,
                         DataProvider.SqlServer.Promenade.Context>(_ => _.UseSqlServer(promCs));
-                    services.AddHealthChecks()
-                        .AddDbContextCheck<OpsContext>()
-                        .AddDbContextCheck<PromenadeContext>();
+                    services.AddHealthChecks();
                     break;
 
                 default:

--- a/src/Promenade.Data/Promenade.Data.csproj
+++ b/src/Promenade.Data/Promenade.Data.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -43,11 +43,10 @@
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.19.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.12" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="5.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="5.0.13" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="5.0.12" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="4.1.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.159</FileVersion>
+    <FileVersion>1.0.0.160</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Startup.cs
+++ b/src/Promenade.Web/Startup.cs
@@ -269,8 +269,7 @@ namespace Ocuda.Promenade.Web
                                 .UseSqlServer(promCs)
                                 .AddInterceptors(new DbLoggingInterceptor()),
                                 poolSize);
-                        services.AddHealthChecks()
-                            .AddDbContextCheck<DataProvider.SqlServer.Promenade.Context>();
+                        services.AddHealthChecks();
                     }
                     else
                     {
@@ -287,8 +286,7 @@ namespace Ocuda.Promenade.Web
                             DataProvider.SqlServer.Promenade.Context>(_ => _
                                 .UseSqlServer(promCs)
                                 .AddInterceptors(new DbLoggingInterceptor()));
-                        services.AddHealthChecks()
-                            .AddDbContextCheck<DataProvider.SqlServer.Promenade.Context>();
+                        services.AddHealthChecks();
                     }
                     else
                     {

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.15.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.12" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.12" />
+    <PackageReference Include="MailKit" Version="3.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="5.0.13" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />

--- a/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
+++ b/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.12" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
- Add guideline to .editorconfig
- Remove database from health check
- MailKit 2.15.0 -> 3.0.0
- Microsoft.AspNetCore.DataProtection.EntityFrameworkCore 5.0.12 -> 5.0.13
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 5.0.12 -> 5.0.13
- Microsoft.EntityFrameworkCore 5.0.12 -> 5.0.13
- Microsoft.EntityFrameworkCore.InMemory 5.0.12 -> 5.0.13
- Microsoft.EntityFrameworkCore.Relational 5.0.12 -> 5.0.13
- Microsoft.EntityFrameworkCore.SqlServer 5.0.12 -> 5.0.13
- Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore 5.0.12 -> 5.0.13