### PR TITLE
Fix bug with call to OcudaCache in WindowsAuth

### DIFF
--- a/src/Ops.Web.WindowsAuth/Ops.Web.WindowsAuth.csproj
+++ b/src/Ops.Web.WindowsAuth/Ops.Web.WindowsAuth.csproj
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/MCLD/ocuda/</RepositoryUrl>
     <TargetFramework>net7.0</TargetFramework>
     <UserSecretsId>eb6c2377-84db-46df-9f5d-fde6a5ab4b8f</UserSecretsId>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Fix bug with call to `OcudaCache` (wasn't being added for injection)
- Fix logging to use injected `ILogger`
- Change logging level if user has zero groups
- Adjust logging levels