### PR TITLE
Digital display improvements

### DIFF
--- a/src/Ops.Controllers/Areas/ContentManagement/DigitalDisplaysController.cs
+++ b/src/Ops.Controllers/Areas/ContentManagement/DigitalDisplaysController.cs
@@ -195,12 +195,12 @@ namespace Ocuda.Ops.Controllers.Areas.ContentManagement
 
         [HttpPost]
         [Route("[action]")]
-        public async Task<IActionResult> DeleteAsset(int digitalDisplayAssetId)
+        public async Task<IActionResult> DeleteAsset(int digitalDisplayAssetId, int page)
         {
             if (!await HasContentManagementRightsAsync())
             {
                 ShowAlertDanger("You do not have permission to remove this asset.");
-                return RedirectToAction(nameof(Assets));
+                return RedirectToAction(nameof(Assets), new { page });
             }
 
             try
@@ -211,7 +211,7 @@ namespace Ocuda.Ops.Controllers.Areas.ContentManagement
             {
                 ShowAlertDanger(oex.Message);
             }
-            return RedirectToAction(nameof(Assets));
+            return RedirectToAction(nameof(Assets), new { page });
         }
 
         [HttpPost]

--- a/src/Ops.Data/Ops/DigitalDisplayAssetSetRepository.cs
+++ b/src/Ops.Data/Ops/DigitalDisplayAssetSetRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -40,6 +41,23 @@ namespace Ocuda.Ops.Data.Ops
             return await DbSet
                 .AsNoTracking()
                 .Where(_ => _.DigitalDisplayAssetId == assetId)
+                .ToListAsync();
+        }
+
+        public async Task<IEnumerable<int>> GetExpiredAsync(DateTime endDate)
+        {
+            return await DbSet
+                .AsNoTracking()
+                .GroupBy(_ => _.DigitalDisplayAssetId)
+                .Select(_ => new
+                {
+                    DigitalDisplayAssetId = _.Key,
+                    LatestEndDate = _.OrderByDescending(d => d.EndDate)
+                        .Select(d => d.EndDate)
+                        .FirstOrDefault()
+                })
+                .Where(_ => _.LatestEndDate <= endDate)
+                .Select(_ => _.DigitalDisplayAssetId)
                 .ToListAsync();
         }
 

--- a/src/Ops.Data/Ops/DigitalDisplayItemRepository.cs
+++ b/src/Ops.Data/Ops/DigitalDisplayItemRepository.cs
@@ -29,5 +29,10 @@ namespace Ocuda.Ops.Data.Ops
         {
             DbSet.RemoveRange(DbSet.Where(_ => _.DigitalDisplayAssetId == assetId));
         }
+
+        public void RemoveForDisplay(int displayId)
+        {
+            DbSet.RemoveRange(DbSet.Where(_ => _.DigitalDisplayId == displayId));
+        }
     }
 }

--- a/src/Ops.Service/DigitalDisplayCleanupService.cs
+++ b/src/Ops.Service/DigitalDisplayCleanupService.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Ocuda.Ops.Service.Abstract;
+using Ocuda.Ops.Service.Interfaces.Ops.Services;
+using Ocuda.Utility.Abstract;
+using Ocuda.Utility.Services.Interfaces;
+
+namespace Ocuda.Ops.Service
+{
+    public class DigitalDisplayCleanupService
+        : BaseService<DigitalDisplayCleanupService>, IDigitalDisplayCleanupService
+    {
+        private readonly IOcudaCache _cache;
+        private readonly IDateTimeProvider _dateTimeProvider;
+        private readonly IDigitalDisplayService _digitalDisplayService;
+
+        public DigitalDisplayCleanupService(IDateTimeProvider dateTimeProvider,
+            IDigitalDisplayService digitalDisplayService,
+            IHttpContextAccessor httpContextAccessor,
+            ILogger<DigitalDisplayCleanupService> logger,
+            IOcudaCache cache) : base(logger, httpContextAccessor)
+        {
+            _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+            _dateTimeProvider = dateTimeProvider
+                ?? throw new ArgumentNullException(nameof(dateTimeProvider));
+            _digitalDisplayService = digitalDisplayService
+                ?? throw new ArgumentNullException(nameof(digitalDisplayService));
+        }
+
+        public async Task CleanupSlidesAsync()
+        {
+            string cacheKey = Utility.Keys.Cache.OpsCleanupSlides;
+            var clear = await _cache.GetStringFromCache(cacheKey);
+            if (string.IsNullOrEmpty(clear))
+            {
+                var now = _dateTimeProvider.Now;
+                await _cache.SaveToCacheAsync(cacheKey, now.ToString("O"), 24);
+                var stopwatch = Stopwatch.StartNew();
+                var slideCount = await _digitalDisplayService
+                    .ClearExpiredAssetsAsync(now.AddDays(-14));
+                if (slideCount > 0)
+                {
+                    _logger.LogInformation("Cleared {SlideCount} expired slides in {ElapsedMs} ms",
+                        slideCount,
+                        stopwatch.ElapsedMilliseconds);
+                }
+            }
+        }
+    }
+}

--- a/src/Ops.Service/DigitalDisplayService.cs
+++ b/src/Ops.Service/DigitalDisplayService.cs
@@ -181,6 +181,7 @@ namespace Ocuda.Ops.Service
         public async Task DeleteDisplayAsync(int displayId)
         {
             var display = await _digitalDisplayRepository.FindAsync(displayId);
+            _digitalDisplayItemRepository.RemoveForDisplay(displayId);
             _digitalDisplayRepository.Remove(display);
             await _digitalDisplayRepository.SaveAsync();
         }

--- a/src/Ops.Service/Interfaces/Ops/Repositories/IDigitalDisplayAssetSetRepository.cs
+++ b/src/Ops.Service/Interfaces/Ops/Repositories/IDigitalDisplayAssetSetRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Ocuda.Ops.Models.Entities;
 
@@ -12,6 +13,8 @@ namespace Ocuda.Ops.Service.Interfaces.Ops.Repositories
         public Task<ICollection<DigitalDisplayAssetSet>> GetAssetsBySetsAsync(IEnumerable<int> setIds);
 
         public Task<ICollection<DigitalDisplayAssetSet>> GetByAssetIdAsync(int assetId);
+
+        public Task<IEnumerable<int>> GetExpiredAsync(DateTime endDate);
 
         public Task<int> GetSetCountContainingAsset(int assetId);
 

--- a/src/Ops.Service/Interfaces/Ops/Repositories/IDigitalDisplayItemRepository.cs
+++ b/src/Ops.Service/Interfaces/Ops/Repositories/IDigitalDisplayItemRepository.cs
@@ -9,5 +9,7 @@ namespace Ocuda.Ops.Service.Interfaces.Ops.Repositories
         public Task<ICollection<DigitalDisplayItem>> GetByDisplayAsync(int displayId);
 
         public void RemoveByAssetId(int assetId);
+
+        public void RemoveForDisplay(int displayId);
     }
 }

--- a/src/Ops.Service/Interfaces/Ops/Services/IDigitalDisplayCleanupService.cs
+++ b/src/Ops.Service/Interfaces/Ops/Services/IDigitalDisplayCleanupService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Ocuda.Ops.Service.Interfaces.Ops.Services
+{
+    public interface IDigitalDisplayCleanupService
+    {
+        public Task CleanupSlidesAsync();
+    }
+}

--- a/src/Ops.Service/Interfaces/Ops/Services/IDigitalDisplayService.cs
+++ b/src/Ops.Service/Interfaces/Ops/Services/IDigitalDisplayService.cs
@@ -20,6 +20,8 @@ namespace Ocuda.Ops.Service.Interfaces.Ops.Services
 
         public Task<IEnumerable<int>> AssignSetAsync(int displayId, int setId);
 
+        public Task<int> ClearExpiredAssetsAsync(DateTime endDate);
+
         public Task DeleteAssetAsync(int digitalDisplayAssetId);
 
         public Task DeleteDisplayAsync(int displayId);

--- a/src/Ops.Web/Areas/ContentManagement/Views/DigitalDisplays/Assets.cshtml
+++ b/src/Ops.Web/Areas/ContentManagement/Views/DigitalDisplays/Assets.cshtml
@@ -104,6 +104,7 @@
 <nav paginate="@Model.PaginateModel"></nav>
 
 <form asp-action="@(nameof(DigitalDisplaysController.DeleteAsset))">
+    <input type="hidden" name="page" value="@Model.PaginateModel.CurrentPage" />
     <div class="modal fade"
          id="deleteAsset"
          data-backdrop="static"

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.228</FileVersion>
+    <FileVersion>1.0.0.229</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Ops.Web/Startup.cs
+++ b/src/Ops.Web/Startup.cs
@@ -489,6 +489,7 @@ namespace Ocuda.Ops.Web
             services.AddScoped<ICoverIssueService, CoverIssueService>();
             services.AddScoped<IDeckService, DeckService>();
             services.AddScoped<IDigitalDisplayService, DigitalDisplayService>();
+            services.AddScoped<IDigitalDisplayCleanupService, DigitalDisplayCleanupService>();
             services.AddScoped<IDigitalDisplaySyncService, DigitalDisplaySyncService>();
             services.AddScoped<IEmediaService, EmediaService>();
             services.AddScoped<IEmailService, EmailService>();

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.228</FileVersion>
+    <FileVersion>1.0.0.229</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Utility/Keys/Cache.cs
+++ b/src/Utility/Keys/Cache.cs
@@ -3,6 +3,11 @@
     public static class Cache
     {
         /// <summary>
+        /// Date and time of last expired slide purge
+        /// </summary>
+        public static readonly string OpsCleanupSlides = "cleanupslides";
+
+        /// <summary>
         /// Status of a digital display, {0} is the digital display id
         /// </summary>
         public static readonly string OpsDigitalDisplayStatus = "dd.{0}";


### PR DESCRIPTION
- Fix #558
- Job to cull old slides that are no longer active for any display at a configurable time span (e.g. 1 week after it's no longer valid) (#363)
