### PR TITLE
Update packages, Docker lock checksums

### DIFF
--- a/docker-lock.json
+++ b/docker-lock.json
@@ -4,24 +4,24 @@
 			{
 				"name": "mcr.microsoft.com/dotnet/sdk",
 				"tag": "8.0",
-				"digest": "b56053d0a8f4627047740941396e76cd9e7a9421c83b1d81b68f10e5019862d7"
+				"digest": "e6a5a8d884609907fa8d468b927df765967f6b22f890ce92bd3ae614ca4ae87e"
 			},
 			{
 				"name": "mcr.microsoft.com/dotnet/aspnet",
 				"tag": "8.0",
-				"digest": "c149fe7e2be3baccf3cc91e9e6cdcca0ce70f7ca30d5f90796d983ff4f27bd9a"
+				"digest": "d5c0d91bc8fe887684b97d5409056270ed78cd23a5123436e842a8114a64d584"
 			}
 		],
 		"Dockerfile_promenade": [
 			{
 				"name": "mcr.microsoft.com/dotnet/sdk",
 				"tag": "8.0",
-				"digest": "b56053d0a8f4627047740941396e76cd9e7a9421c83b1d81b68f10e5019862d7"
+				"digest": "e6a5a8d884609907fa8d468b927df765967f6b22f890ce92bd3ae614ca4ae87e"
 			},
 			{
 				"name": "mcr.microsoft.com/dotnet/aspnet",
 				"tag": "8.0",
-				"digest": "c149fe7e2be3baccf3cc91e9e6cdcca0ce70f7ca30d5f90796d983ff4f27bd9a"
+				"digest": "d5c0d91bc8fe887684b97d5409056270ed78cd23a5123436e842a8114a64d584"
 			}
 		]
 	}

--- a/src/Ops.Controllers/Ops.Controllers.csproj
+++ b/src/Ops.Controllers/Ops.Controllers.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="CommonMark.NET" Version="0.15.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUglify" Version="1.21.15" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.Data/Ops.Data.csproj
+++ b/src/Ops.Data/Ops.Data.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
   </ItemGroup>
 
 </Project>

--- a/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
+++ b/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.17" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ops.Service/Ops.Service.csproj
+++ b/src/Ops.Service/Ops.Service.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.6.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>

--- a/src/Ops.Web.WindowsAuth/Ops.Web.WindowsAuth.csproj
+++ b/src/Ops.Web.WindowsAuth/Ops.Web.WindowsAuth.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.17" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
   </ItemGroup>
 

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.311</FileVersion>
+    <FileVersion>1.0.0.312</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>
@@ -38,14 +38,14 @@
 
   <ItemGroup>
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.436" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.16">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.17">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.16" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.17" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>

--- a/src/Promenade.Data/Promenade.Data.csproj
+++ b/src/Promenade.Data/Promenade.Data.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.17" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.311</FileVersion>
+    <FileVersion>1.0.0.312</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>
@@ -39,10 +39,10 @@
   <ItemGroup>
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.436" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.16" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.16" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.17" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.17" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.17" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -20,8 +20,8 @@
 
   <ItemGroup>
     <PackageReference Include="MailKit" Version="4.12.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.16" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.16" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.17" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.17" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />

--- a/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
+++ b/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.16" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.17" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/i18n/i18n.Test/i18n.Test.csproj
+++ b/test/i18n/i18n.Test/i18n.Test.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Microsoft.AspNetCore.DataProtection 8.0.16 -> 8.0.17
- Microsoft.AspNetCore.DataProtection.EntityFrameworkCore 8.0.16 -> 8.0.17
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 8.0.16 -> 8.0.17
- Microsoft.EntityFrameworkCore 8.0.16 -> 8.0.17
- Microsoft.EntityFrameworkCore.InMemory 8.0.16 -> 8.0.17
- Microsoft.EntityFrameworkCore.Relational 8.0.16 -> 8.0.17
- Microsoft.EntityFrameworkCore.SqlServer 8.0.16 -> 8.0.17
- Microsoft.EntityFrameworkCore.Tools 8.0.16 -> 8.0.17
- Microsoft.Extensions.Caching.StackExchangeRedis 8.0.16 -> 8.0.17
- Microsoft.NET.Test.Sdk 17.14.0 -> 17.14.1
- SixLabors.ImageSharp 3.1.8 -> 3.1.10
- unit.runner.visualstudio 3.1.0 -> 3.1.1
- xunit.runner.visualstudio 3.1.0 -> 3.1.1