### PR TITLE
Remove individual LDAP port config

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -2,11 +2,9 @@
 
 ## Framework
 
-Ocuda targets the ASP.NET 6 framework. For that to work currently
-you must:
+Ocuda targets the ASP.NET framework. For that to work currently you must:
 
-- Install the [.NET 8
-SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
+- Install the [.NET 8 SDK](https://dotnet.microsoft.com/download/dotnet/8.0)
 - [Visual Studio 2022](https://visualstudio.microsoft.com/vs/)
 
 ## Project layout
@@ -135,15 +133,15 @@ beginning of authenticated users (do not include the slash)
 write out http error logs in the same location but with the value of
 this setting in the filename
 - `Ops.Instance` - configure an instance name for more specific logging
-- `Ops.LDAPDN` - Distinguished name of an LDAP user for performing
-lookups, similar to "CN=Users Real Name,OU=Organizational
+- `Ops.LDAPUser` - LDAP user for performing lookups
 Unit,DC=domain,DC=tld"
-- `Ops.LDAPPassword` - Password for the LDAPDN user
-- `Ops.LDAPPort` - Port to connect to for LDAP, defaults to 389
+- `Ops.LDAPPassword` - Password for the LdapUser user
 - `Ops.LDAPSearchBase` - Search base for querying usernames, similar to
 "OU=Users,OU=Organizational Unit,DC=domain,DC=tld"
 - `Ops.LDAPServer` - LDAP server to query for information based on the
-user's username
+user's username, configured as a server name or a server name, a colon,
+and a port. Currently using ports in Linux do not work, it will begin
+to work [when the project transitions to ASP.NET 9](https://github.com/dotnet/runtime/issues/59701)
 - `Ops.RollingLogLocation` - path of where to write log files which
 rotate daily, if unset no rolling log is written
 - `Ops.SessionTimeoutMinutes` - defaults to 2 hours - amount of time in

--- a/src/Ops.Service/LdapService.cs
+++ b/src/Ops.Service/LdapService.cs
@@ -413,15 +413,7 @@ namespace Ocuda.Ops.Service
                     && !string.IsNullOrEmpty(ldapPassword)
                     && !string.IsNullOrEmpty(ldapSearchBase))
                 {
-                    int port = 389;
-                    if (!string.IsNullOrEmpty(_config[Configuration.OpsLdapPort])
-                        && !int.TryParse(_config[Configuration.OpsLdapPort], out port))
-                    {
-                        _logger.LogWarning("Invalid port specified: {InvalidPort}",
-                            _config[Configuration.OpsLdapPort]);
-                    }
-
-                    var endpoint = new LdapDirectoryIdentifier($"{ldapServer}:{port}");
+                    var endpoint = new LdapDirectoryIdentifier(ldapServer);
                     var credential = new NetworkCredential(ldapUser, ldapPassword, domainName);
 
                     using var connection = new LdapConnection(endpoint, credential)

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.325</FileVersion>
+    <FileVersion>1.0.0.326</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.325</FileVersion>
+    <FileVersion>1.0.0.326</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>

--- a/src/Utility/Keys/Configuration.cs
+++ b/src/Utility/Keys/Configuration.cs
@@ -35,7 +35,6 @@
         public static readonly string OpsHttpErrorFileTag = "Ops.HttpErrorFileTag";
         public static readonly string OpsImageOptimizerUsername = "Ops.ImageOptimizerUsername";
         public static readonly string OpsLdapPassword = "Ops.LDAPPassword";
-        public static readonly string OpsLdapPort = "Ops.LDAPPort";
         public static readonly string OpsLdapSearchBase = "Ops.LDAPSearchBase";
         public static readonly string OpsLdapServer = "Ops.LDAPServer";
         public static readonly string OpsLdapUser = "Ops.LDAPUser";


### PR DESCRIPTION
Including the port with the LDAP server name was causing errors in Linux but not in Windows. This will be fixed in .NET 9.