### PR TITLE
Update back-end packages; Docker lock checksums

### DIFF
--- a/docker-lock.json
+++ b/docker-lock.json
@@ -4,24 +4,24 @@
 			{
 				"name": "mcr.microsoft.com/dotnet/sdk",
 				"tag": "8.0",
-				"digest": "dd09bcce84d9130e7f3e85c83a8ce9709e1d95e45c48c722a0d7923b38d8024c"
+				"digest": "ec47373b40fc22a31c891c5be8df83f8cbadc24e785b10899545e33a1a1c2183"
 			},
 			{
 				"name": "mcr.microsoft.com/dotnet/aspnet",
 				"tag": "8.0",
-				"digest": "f24d74e8185b14aba4c7563e059e0f526699d4730998a83515d3af03058e1266"
+				"digest": "8c7de8ca26baa56530cdc3d55b5563420ee2a302619ad808c53ec64613143771"
 			}
 		],
 		"Dockerfile_promenade": [
 			{
 				"name": "mcr.microsoft.com/dotnet/sdk",
 				"tag": "8.0",
-				"digest": "dd09bcce84d9130e7f3e85c83a8ce9709e1d95e45c48c722a0d7923b38d8024c"
+				"digest": "ec47373b40fc22a31c891c5be8df83f8cbadc24e785b10899545e33a1a1c2183"
 			},
 			{
 				"name": "mcr.microsoft.com/dotnet/aspnet",
 				"tag": "8.0",
-				"digest": "f24d74e8185b14aba4c7563e059e0f526699d4730998a83515d3af03058e1266"
+				"digest": "8c7de8ca26baa56530cdc3d55b5563420ee2a302619ad808c53ec64613143771"
 			}
 		]
 	}

--- a/src/Ops.Data/Ops.Data.csproj
+++ b/src/Ops.Data/Ops.Data.csproj
@@ -22,8 +22,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.25" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
   </ItemGroup>
 
 </Project>

--- a/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
+++ b/src/Ops.DataProvider.SqlServer.Ops/Ops.DataProvider.SqlServer.Ops.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Ops.DataProvider.SqlServer.Promenade/Ops.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Ops.Service/Ops.Service.csproj
+++ b/src/Ops.Service/Ops.Service.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="DNParser" Version="1.3.5" />
     <PackageReference Include="ExcelDataReader" Version="3.8.0" />
     <PackageReference Include="ImageOptimApi" Version="1.1.0" />
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.1" />
     <PackageReference Include="NLayer" Version="1.16.0" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />

--- a/src/Ops.Web/Ops.Web.csproj
+++ b/src/Ops.Web/Ops.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.354</FileVersion>
+    <FileVersion>1.0.0.355</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>
@@ -38,14 +38,14 @@
 
   <ItemGroup>
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.25" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.25">
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.26">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.25" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.26" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>

--- a/src/Promenade.Data/Promenade.Data.csproj
+++ b/src/Promenade.Data/Promenade.Data.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.25" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
   </ItemGroup>
 
 </Project>

--- a/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
+++ b/src/Promenade.DataProvider.SqlServer.Promenade/Promenade.DataProvider.SqlServer.Promenade.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.26" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Promenade.Web/Promenade.Web.csproj
+++ b/src/Promenade.Web/Promenade.Web.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>../../OcudaRuleSet.ruleset</CodeAnalysisRuleSet>
     <Company>Maricopa County Library District</Company>
     <Copyright>Copyright 2018 Maricopa County Library District</Copyright>
-    <FileVersion>1.0.0.354</FileVersion>
+    <FileVersion>1.0.0.355</FileVersion>
     <LangVersion>Latest</LangVersion>
     <PackageLicenseUrl>https://github.com/MCLD/ocuda/blob/develop/LICENSE</PackageLicenseUrl>
     <Product>Ocuda</Product>
@@ -38,10 +38,10 @@
 
   <ItemGroup>
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.477" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.25" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.25" />
-    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="8.0.26" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.26" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.3" />
     <PackageReference Include="System.Text.Encodings.Web" Version="8.0.0" />
   </ItemGroup>

--- a/src/Utility/Utility.csproj
+++ b/src/Utility/Utility.csproj
@@ -19,9 +19,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="4.15.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.25" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.25" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.26" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.26" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />

--- a/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
+++ b/test/Ops/Ops.Data.Test/Ops.Data.Test.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.25" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.26" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
- MailKit 4.15.1 -> 4.16.0
- Microsoft.EntityFrameworkCore.Tools 8.0.25 -> 8.0.26
- Microsoft.AspNetCore.DataProtection 8.0.25 -> 8.0.26
- Microsoft.AspNetCore.DataProtection.EntityFrameworkCore 8.0.25 -> 8.0.26
- Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation 8.0.25 -> 8.0.26
- Microsoft.EntityFrameworkCore 8.0.25 -> 8.0.26
- Microsoft.EntityFrameworkCore.InMemory 8.0.25 -> 8.0.26
- Microsoft.EntityFrameworkCore.Relational 8.0.25 -> 8.0.26
- Microsoft.EntityFrameworkCore.SqlServer 8.0.25 -> 8.0.26
- Microsoft.EntityFrameworkCore.Tools 8.0.25 -> 8.0.26
- Microsoft.Extensions.Caching.StackExchangeRedis 8.0.25 -> 8.0.26